### PR TITLE
added `errors` field to JUnitTestSuite struct to support Jenkins JUnit publisher

### DIFF
--- a/pkg/unittest/formatter/junit_report_xml.go
+++ b/pkg/unittest/formatter/junit_report_xml.go
@@ -19,6 +19,7 @@ type JUnitTestSuite struct {
 	XMLName    xml.Name        `xml:"testsuite"`
 	Tests      int             `xml:"tests,attr"`
 	Failures   int             `xml:"failures,attr"`
+	Errors     int             `xml:"errors,attr"`
 	Time       string          `xml:"time,attr"`
 	Name       string          `xml:"name,attr"`
 	Properties []JUnitProperty `xml:"properties>property,omitempty"`


### PR DESCRIPTION
The field "errors" in JUnitTestSuite struct of the generated JUnit reports are missing, thus Jenkins+ JUnit refusing to process them.


The error message reads link follows:

```
org.jenkinsci.plugins.xunit.service.TransformerException: The result file '/home/jenkins/agent/jobs/xxx/build/charts/my-chart/target/test/my-chart.xml' for the metric 'JUnit' is not valid. The result file has been skipped.
```

The PR adding just this field.

Plugin-Version used is v0.3.0.
Helm version is 3.11.1.