### PR TITLE
docs: fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you are ready for writing tests, check the [DOCUMENT](./DOCUMENT.md) for the 
 ## Install
 
 ```
-$ helm plugin install https://github.com/helm-unittest/helm-unittest
+$ helm plugin install https://github.com/helm-unittest/helm-unittest.git
 ```
 
 It will install the latest version of binary into helm plugin directory.


### PR DESCRIPTION
If i don't add the `.git` suffix helm v3.11.1+ will error out with:

```
Error: Unable to retrieve local repo information: exit status 1
```