### PR TITLE
fix: regression of isNull / isNotNull

### DIFF
--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -194,8 +194,8 @@ var assertTypeMapping = map[string]assertTypeDef{
 	"containsDocument":  {reflect.TypeOf(validators.ContainsDocumentValidator{}), false, true},
 	"lengthEqual":       {reflect.TypeOf(validators.LengthEqualDocumentsValidator{}), false, true},
 	"notLengthEqual":    {reflect.TypeOf(validators.LengthEqualDocumentsValidator{}), true, true},
-	"isNull":            {reflect.TypeOf(validators.ExistsValidator{}), false, true},
-	"isNotNull":         {reflect.TypeOf(validators.ExistsValidator{}), true, true},
+	"isNull":            {reflect.TypeOf(validators.ExistsValidator{}), true, true},
+	"isNotNull":         {reflect.TypeOf(validators.ExistsValidator{}), false, true},
 	"isEmpty":           {reflect.TypeOf(validators.IsNullOrEmptyValidator{}), false, true},
 	"isNotEmpty":        {reflect.TypeOf(validators.IsNullOrEmptyValidator{}), true, true},
 }


### PR DESCRIPTION
There seems to be a small regression upon the introduction of the new `exists`/`notExists` validators

Usage of `isNull` in case a property will not exist ~ is null

```
     asserts:
       - isNull:
           path: spec.template.spec.containers[0].readinessProbe
```
```
 FAIL  service.deployment_test.yaml	tests/deployment_test.yaml
	- should not enable option by default

		- asserts[4] `isNull` fail
			Template:	service/templates/deployment.yaml
			DocumentIndex:	0
			Path:	spec.template.spec.containers[0].readinessProbe expected to exists
```

And the same outcome for `exists` ( which should actually be `notExists` )
```
     asserts:
      - exists:
           path: spec.template.spec.containers[0].readinessProbe
```

```
FAIL  service.deployment_test.yaml	tests/deployment_est.yaml
	- should not enable option by default

		- asserts[4] `exists` fail
			Template:	service/templates/deployment.yaml
			DocumentIndex:	0
			Path:	spec.template.spec.containers[0].readinessProbe expected to exists
```
