### PR TITLE
Update to go 1.20.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/go:1.20.3
+      - image: cimg/go:1.20.4
     steps:
       - checkout
       - run:
@@ -31,7 +31,7 @@ jobs:
 
   distribute:
     docker:
-      - image: golang:1.20.3
+      - image: golang:1.20.4
     steps:
       - checkout
       - run:
@@ -45,7 +45,7 @@ jobs:
 
   distribute_docker:
     docker:
-      - image: cimg/go:1.20.3
+      - image: cimg/go:1.20.4
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
There are a few CVE in the current Go version, see https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU