### PR TITLE
Bugfix/negative contains document

### DIFF
--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -234,7 +234,6 @@ func (t *TestJob) getUserValues() ([]byte, error) {
 
 // render the chart and return result map
 func (t *TestJob) renderV3Chart(targetChart *v3chart.Chart, userValues []byte) (map[string]string, bool, error) {
-	renderSucceed := true
 	values, err := v3util.ReadValues(userValues)
 	if err != nil {
 		return nil, false, err
@@ -274,6 +273,7 @@ func (t *TestJob) renderV3Chart(targetChart *v3chart.Chart, userValues []byte) (
 
 	outputOfFiles, err := v3engine.Render(filteredChart, vals)
 
+	var renderSucceed bool
 	outputOfFiles, renderSucceed, err = t.translateErrorToOutputFiles(err, outputOfFiles)
 	if err != nil {
 		return nil, false, err

--- a/pkg/unittest/validators/contains_document_validator.go
+++ b/pkg/unittest/validators/contains_document_validator.go
@@ -24,13 +24,13 @@ func (v ContainsDocumentValidator) failInfo(actual interface{}, index int, not b
 	)
 }
 
-func (v ContainsDocumentValidator) validateManifest(manifest common.K8sManifest, negative bool) bool {
-	if kind, ok := manifest["kind"].(string); (ok && kind == v.Kind) == negative {
+func (v ContainsDocumentValidator) validateManifest(manifest common.K8sManifest) bool {
+	if kind, ok := manifest["kind"].(string); ok && kind != v.Kind {
 		// if no match, move onto next document
 		return false
 	}
 
-	if api, ok := manifest["apiVersion"].(string); (ok && api == v.APIVersion) == negative {
+	if api, ok := manifest["apiVersion"].(string); ok && api != v.APIVersion {
 		// if no match, move onto next document
 		return false
 	}
@@ -42,7 +42,7 @@ func (v ContainsDocumentValidator) validateManifest(manifest common.K8sManifest,
 			return false
 		}
 
-		if (actual[0] == v.Name) == negative {
+		if actual[0] != v.Name {
 			return false
 		}
 	}
@@ -54,7 +54,7 @@ func (v ContainsDocumentValidator) validateManifest(manifest common.K8sManifest,
 			return false
 		}
 
-		if (actual[0] == v.Namespace) == negative {
+		if actual[0] != v.Namespace {
 			return false
 		}
 	}
@@ -73,13 +73,13 @@ func (v ContainsDocumentValidator) Validate(context *ValidateContext) (bool, []s
 	validateErrors := make([]string, 0)
 
 	for _, manifest := range manifests {
-		validateSuccess = v.validateManifest(manifest, context.Negative)
+		validateSuccess = v.validateManifest(manifest)
 		if validateSuccess {
 			break
 		}
 		continue
 	}
-	if !validateSuccess {
+	if !validateSuccess && !context.Negative {
 		errorMessage := v.failInfo(v.Kind, 0, context.Negative)
 		validateErrors = append(validateErrors, errorMessage...)
 	}

--- a/pkg/unittest/validators/contains_document_validator_test.go
+++ b/pkg/unittest/validators/contains_document_validator_test.go
@@ -24,6 +24,39 @@ metadata:
   namespace: foo
 `
 
+func TestContainsDocumentValidatorWhenEmptyNOk(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"Service",
+		"v1",
+		"bar",
+		"foo",
+	}
+	pass, diff := validator.Validate(&ValidateContext{
+		Index: -1,
+		Docs:  []common.K8sManifest{},
+	})
+
+	assert.False(t, pass)
+	assert.Equal(t, []string{"DocumentIndex:	0", "Expected to contain document:", "	Kind = Service, apiVersion = v1"}, diff)
+}
+
+func TestContainsDocumentValidatorNegativeWhenEmptyOk(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"Service",
+		"v1",
+		"bar",
+		"foo",
+	}
+	pass, diff := validator.Validate(&ValidateContext{
+		Index:    -1,
+		Docs:     []common.K8sManifest{},
+		Negative: true,
+	})
+
+	assert.False(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
 func TestContainsDocumentValidatorWhenOk(t *testing.T) {
 	validator := ContainsDocumentValidator{
 		"Service",


### PR DESCRIPTION
Correct negative contains document, when an empty document is returned.
Including testvalidation. (resolves #145)