### PR TITLE
Add Sonar output formatter

### DIFF
--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -148,7 +148,7 @@ func init() {
 
 	cmd.PersistentFlags().StringVarP(
 		&testConfig.outputType, "output-type", "t", "XUnit",
-		"output-type the file-format where testresults are written in, accepted types are (JUnit, NUnit, XUnit)",
+		"output-type the file-format where testresults are written in, accepted types are (JUnit, NUnit, XUnit, Sonar)",
 	)
 
 	cmd.PersistentFlags().BoolVarP(

--- a/pkg/unittest/formatter/formatter.go
+++ b/pkg/unittest/formatter/formatter.go
@@ -41,6 +41,10 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%.3f", d.Seconds())
 }
 
+func formatDurationMilliSeconds(d time.Duration) string {
+	return fmt.Sprintf("%d", d.Milliseconds())
+}
+
 func writeContentToFile(noXMLHeader bool, content interface{}, w io.Writer) error {
 
 	// to xml
@@ -84,6 +88,8 @@ func NewFormatter(outputFile, outputType string) Formatter {
 			return NewNUnitReportXML()
 		case "xunit":
 			return NewXUnitReportXML()
+		case "sonar":
+			return NewSonarReportXML()
 		default:
 			return nil
 		}

--- a/pkg/unittest/formatter/formatter_test.go
+++ b/pkg/unittest/formatter/formatter_test.go
@@ -112,3 +112,14 @@ func TestNewFormatterWithOutputFileAndOutputTypeXUnit(t *testing.T) {
 	assert.NotNil(sut)
 	assert.DirExists(givenDirectory)
 }
+
+func TestNewFormatterWithOutputFileAndOutputTypeSonar(t *testing.T) {
+	assert := assert.New(t)
+	outputType := "Sonar"
+	given := testOutputFile
+	givenDirectory := filepath.Dir(given)
+	defer os.Remove(givenDirectory)
+	sut := NewFormatter(given, outputType)
+	assert.NotNil(sut)
+	assert.DirExists(givenDirectory)
+}

--- a/pkg/unittest/formatter/sonar_report_xml.go
+++ b/pkg/unittest/formatter/sonar_report_xml.go
@@ -35,16 +35,22 @@ type SonarTestCase struct {
 // SonarSkipped is set when a test case was skipped.
 type SonarSkipped struct {
 	XMLName xml.Name `xml:"skipped"`
+	Message string   `xml:"message,attr"`
+	Reason  string   `xml:",cdata"`
 }
 
 // SonarError is set when a test case have an error.
 type SonarError struct {
-	XMLName xml.Name `xml:"error"`
+	XMLName    xml.Name `xml:"error"`
+	Message    string   `xml:"message,attr"`
+	Stacktrace string   `xml:",cdata"`
 }
 
 // SonarFailure is set when a test case fails.
 type SonarFailure struct {
-	XMLName xml.Name `xml:"failure"`
+	XMLName    xml.Name `xml:"failure"`
+	Message    string   `xml:"message,attr"`
+	Stacktrace string   `xml:",cdata"`
 }
 
 type SonarReportXML struct{}
@@ -55,7 +61,7 @@ func NewSonarReportXML() Formatter {
 }
 
 // WriteTestOutput writes a Sonar xml representation of the given report
-// in the format described at https://docs.Sonar.org/latest/analyzing-source-code/test-coverage/generic-test-data/#generic-test-execution
+// in the format described at https://docs.sonarqube.org/8.9/analyzing-source-code/generic-test-data/
 func (j *SonarReportXML) WriteTestOutput(testSuiteResults []*results.TestSuiteResult, noXMLHeader bool, w io.Writer) error {
 	suites := SonarTestExecutions{}
 	suites.Version = 1
@@ -70,9 +76,9 @@ func (j *SonarReportXML) WriteTestOutput(testSuiteResults []*results.TestSuiteRe
 
 			if !test.Passed {
 				if test.ExecError != nil {
-					testCase.Error = j.createSonarError()
+					testCase.Error = j.createSonarError("Error", test.ExecError.Error())
 				} else {
-					testCase.Failure = j.createSonarFailure()
+					testCase.Failure = j.createSonarFailure("Failed", test.Stringify())
 				}
 			}
 
@@ -108,16 +114,25 @@ func (j *SonarReportXML) createSonarTestCase(testJobResult *results.TestJobResul
 	}
 }
 
-func (j *SonarReportXML) createSonarError() *SonarError {
-	return &SonarError{}
+func (j *SonarReportXML) createSonarError(message string, stacktrace string) *SonarError {
+	return &SonarError{
+		Message:    message,
+		Stacktrace: stacktrace,
+	}
 }
 
-func (j *SonarReportXML) createSonarFailure() *SonarFailure {
-	return &SonarFailure{}
+func (j *SonarReportXML) createSonarFailure(message string, stacktrace string) *SonarFailure {
+	return &SonarFailure{
+		Message:    message,
+		Stacktrace: stacktrace,
+	}
 }
 
 /* skip status currently not supported
-func (j *SonarReportXML) createSonarSkipped() *SonarSkipped {
-	return &SonarSkipped{}
+func (j *SonarReportXML) createSonarSkipped(message string, reason string) *SonarSkipped {
+	return &SonarSkipped{
+		Message:    message,
+		Reason: reason,
+	}
 }
 */

--- a/pkg/unittest/formatter/sonar_report_xml.go
+++ b/pkg/unittest/formatter/sonar_report_xml.go
@@ -1,0 +1,123 @@
+package formatter
+
+import (
+	"encoding/xml"
+	"io"
+
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/results"
+)
+
+// SonarTestExecutions is a collection of Sonar files.
+type SonarTestExecutions struct {
+	XMLName xml.Name    `xml:"testExecutions"`
+	Version int         `xml:"version,attr"`
+	Files   []SonarFile `xml:"file"`
+}
+
+// SonarFile is a single Sonar test file suite which may contain many
+// testCases.
+type SonarFile struct {
+	XMLName   xml.Name        `xml:"file"`
+	Path      string          `xml:"path,attr"`
+	TestCases []SonarTestCase `xml:"testCase"`
+}
+
+// SonarTestCase is a single test case with its result.
+type SonarTestCase struct {
+	XMLName  xml.Name      `xml:"testCase"`
+	Name     string        `xml:"name,attr"`
+	Duration string        `xml:"duration,attr"`
+	Error    *SonarError   `xml:"error,omitempty"`
+	Skipped  *SonarSkipped `xml:"skipped,omitempty"`
+	Failure  *SonarFailure `xml:"failure,omitempty"`
+}
+
+// SonarSkipped is set when a test case was skipped.
+type SonarSkipped struct {
+	XMLName xml.Name `xml:"skipped"`
+}
+
+// SonarError is set when a test case have an error.
+type SonarError struct {
+	XMLName xml.Name `xml:"error"`
+}
+
+// SonarFailure is set when a test case fails.
+type SonarFailure struct {
+	XMLName xml.Name `xml:"failure"`
+}
+
+type SonarReportXML struct{}
+
+// NewSonarReportXML Constructor
+func NewSonarReportXML() Formatter {
+	return &SonarReportXML{}
+}
+
+// WriteTestOutput writes a Sonar xml representation of the given report
+// in the format described at https://docs.Sonar.org/latest/analyzing-source-code/test-coverage/generic-test-data/#generic-test-execution
+func (j *SonarReportXML) WriteTestOutput(testSuiteResults []*results.TestSuiteResult, noXMLHeader bool, w io.Writer) error {
+	suites := SonarTestExecutions{}
+	suites.Version = 1
+
+	// convert TestSuiteResults to Sonar test suites
+	for _, testSuiteResult := range testSuiteResults {
+		ts := j.createSonarTestSuite(testSuiteResult)
+
+		// individual test cases
+		for _, test := range testSuiteResult.TestsResult {
+			testCase := j.createSonarTestCase(test)
+
+			if !test.Passed {
+				if test.ExecError != nil {
+					testCase.Error = j.createSonarError()
+				} else {
+					testCase.Failure = j.createSonarFailure()
+				}
+			}
+
+			// skip status currently not supported
+			// testCase.Skipped = j.createSonarSkipped()
+
+			ts.TestCases = append(ts.TestCases, testCase)
+		}
+
+		suites.Files = append(suites.Files, ts)
+	}
+
+	// to xml
+	if err := writeContentToFile(noXMLHeader, suites, w); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (j *SonarReportXML) createSonarTestSuite(testSuiteResult *results.TestSuiteResult) SonarFile {
+	return SonarFile{
+		Path:      testSuiteResult.FilePath,
+		TestCases: []SonarTestCase{},
+	}
+}
+
+func (j *SonarReportXML) createSonarTestCase(testJobResult *results.TestJobResult) SonarTestCase {
+	return SonarTestCase{
+		Name:     testJobResult.DisplayName,
+		Duration: formatDurationMilliSeconds(testJobResult.Duration),
+		Failure:  nil,
+	}
+}
+
+func (j *SonarReportXML) createSonarError() *SonarError {
+	return &SonarError{}
+}
+
+func (j *SonarReportXML) createSonarFailure() *SonarFailure {
+	return &SonarFailure{}
+}
+
+/* skip status currently not supported
+func (j *SonarReportXML) createSonarSkipped() *SonarSkipped {
+	return &SonarSkipped{}
+}
+*/

--- a/pkg/unittest/formatter/sonar_report_xml_test.go
+++ b/pkg/unittest/formatter/sonar_report_xml_test.go
@@ -1,0 +1,182 @@
+package formatter_test
+
+import (
+	"encoding/xml"
+	. "github.com/helm-unittest/helm-unittest/pkg/unittest/formatter"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/results"
+	"github.com/stretchr/testify/assert"
+	"path"
+	"testing"
+	"time"
+)
+
+func createSonarTestCase(name string, duration string, isError bool, isFailed bool) SonarTestCase {
+	testCase := SonarTestCase{
+		Name:     name,
+		Duration: duration,
+	}
+
+	if isError {
+		testCase.Error = &SonarError{}
+	}
+
+	if isFailed {
+		testCase.Failure = &SonarFailure{}
+	}
+
+	return testCase
+}
+
+func validateSonarFiles(assert *assert.Assertions, expected, actual []SonarFile) {
+	assert.Equal(len(expected), len(actual))
+
+	for i := 0; i < len(actual); i++ {
+		assert.Equal(expected[i].Path, actual[i].Path)
+		validateSonarTestCases(assert, expected[i].TestCases, actual[i].TestCases)
+	}
+}
+
+func validateSonarTestCases(assert *assert.Assertions, expected, actual []SonarTestCase) {
+	assert.Equal(len(expected), len(actual))
+
+	for i := 0; i < len(actual); i++ {
+		assert.Equal(expected[i].Name, actual[i].Name)
+		assert.Equal(expected[i].Duration, actual[i].Duration)
+
+	}
+}
+
+func TestWriteTestOutputAsSonarNoTests(t *testing.T) {
+	_assert := assert.New(t)
+	outputFile := path.Join(tmpNunitTestDir, "Sonar_Test_Output.xml")
+
+	expected := SonarTestExecutions{
+		Version: 1,
+	}
+
+	var given []*results.TestSuiteResult
+
+	sut := NewSonarReportXML()
+	byteValue := loadFormatterTestcase(_assert, outputFile, given, sut)
+
+	var actual SonarTestExecutions
+	err := xml.Unmarshal(byteValue, &actual)
+	if err != nil {
+		_assert.Fail(err.Error())
+		return
+	}
+
+	_assert.Equal(expected.Version, actual.Version)
+	validateSonarFiles(_assert, expected.Files, actual.Files)
+}
+
+func TestWriteTestOutputAsSonarMinimalSuccess(t *testing.T) {
+	_assert := assert.New(t)
+	outputFile := path.Join(tmpNunitTestDir, "Sonar_Test_Output.xml")
+	testSuiteDisplayName := "TestingSuiteSuccess"
+	testCaseDisplayName := "TestCaseSuccessSuccess"
+
+	expected := SonarTestExecutions{
+		Files: []SonarFile{
+			{
+				Path: outputFile,
+				TestCases: []SonarTestCase{
+					createSonarTestCase(
+						testCaseDisplayName,
+						"12000",
+						false,
+						false,
+					),
+				},
+			},
+		},
+		Version: 1,
+	}
+
+	given := []*results.TestSuiteResult{
+		{
+			DisplayName: testSuiteDisplayName,
+			FilePath:    outputFile,
+			Passed:      true,
+			TestsResult: []*results.TestJobResult{
+				createTestJobResult(testCaseDisplayName, "", true, nil),
+			},
+		},
+	}
+	given[0].TestsResult[0].Duration, _ = time.ParseDuration("12s")
+
+	sut := NewSonarReportXML()
+	byteValue := loadFormatterTestcase(_assert, outputFile, given, sut)
+
+	var actual SonarTestExecutions
+	err := xml.Unmarshal(byteValue, &actual)
+	if err != nil {
+		_assert.Fail(err.Error())
+	}
+
+	_assert.Equal(expected.Version, actual.Version)
+	validateSonarFiles(_assert, expected.Files, actual.Files)
+}
+
+func TestWriteTestOutputAsSonarWithErrorsAndFailures(t *testing.T) {
+	_assert := assert.New(t)
+	outputFile := path.Join(tmpNunitTestDir, "Sonar_Test_Output.xml")
+	testSuiteDisplayName := "TestingSuiteFailuresAndErrors"
+	testCaseDisplayNameError := "TestCaseError"
+	testCaseDisplayNameFailure := "TestCaseFailure"
+	assertionFailure := "AssertionFailure"
+	assertionType := "equal"
+
+	expected := SonarTestExecutions{
+		Files: []SonarFile{
+			{
+				Path: outputFile,
+				TestCases: []SonarTestCase{
+					createSonarTestCase(
+						testCaseDisplayNameError,
+						"123",
+						true,
+						false,
+					),
+					createSonarTestCase(
+						testCaseDisplayNameFailure,
+						"456",
+						false,
+						true,
+					),
+				},
+			},
+		},
+		Version: 1,
+	}
+
+	assertionResults := []*results.AssertionResult{
+		createAssertionResult(0, false, false, assertionType, assertionFailure, ""),
+	}
+
+	given := []*results.TestSuiteResult{
+		{
+			DisplayName: testSuiteDisplayName,
+			FilePath:    outputFile,
+			Passed:      true,
+			TestsResult: []*results.TestJobResult{
+				createTestJobResult(testCaseDisplayNameError, "TheError", false, nil),
+				createTestJobResult(testCaseDisplayNameFailure, "", false, assertionResults),
+			},
+		},
+	}
+	given[0].TestsResult[0].Duration, _ = time.ParseDuration("123ms")
+	given[0].TestsResult[1].Duration, _ = time.ParseDuration("456ms")
+
+	sut := NewSonarReportXML()
+	byteValue := loadFormatterTestcase(_assert, outputFile, given, sut)
+
+	var actual SonarTestExecutions
+	err := xml.Unmarshal(byteValue, &actual)
+	if err != nil {
+		_assert.Fail(err.Error())
+	}
+
+	_assert.Equal(expected.Version, actual.Version)
+	validateSonarFiles(_assert, expected.Files, actual.Files)
+}


### PR DESCRIPTION
Hello, 

this PR adds a new output formatter : Sonar

This is a pretty simple format described here:  https://docs.sonarqube.org/8.9/analyzing-source-code/generic-test-data/

When executed against a chart containing some errors and output file loaded in sonarcloud, the coverage > Tests measure is :  

<img width="337" alt="image" src="https://github.com/helm-unittest/helm-unittest/assets/16031094/64592dc7-4e58-4642-bd0c-a76bdfba6623">

```
Charts:      1 failed, 0 passed, 1 total
Test Suites: 3 failed, 4 passed, 7 total
Tests:       3 failed, 1 errored, 14 passed, 17 total
Snapshot:    4 passed, 4 total
Time:        102.302054ms
```

Even if they are mandatory, it seems that Failure & Error messages are never visible on the Sonar UI.
They are deprecated in the newer version : 
https://docs.sonarqube.org/latest/analyzing-source-code/test-coverage/generic-test-data/#generic-test-execution

Also, i've added some logic about the skip tests in comments as it's not supported yet
