### PR TITLE
fix: schema definition types

### DIFF
--- a/schema/helm-testsuite.json
+++ b/schema/helm-testsuite.json
@@ -797,14 +797,14 @@
       "markdownDescription": "**capabilities** (object) _optional_\n\nDefine the `{{ .Capabilities }}` object.",
       "properties": {
         "majorVersion": {
-          "type": "string",
+          "type": "integer",
           "description": "The kubernetes major version, default to the major version which is set by helm.",
-          "markdownDescription": "**majorVersion** (string) _optional_\n\nThe kubernetes major version, default to the major version which is set by helm."
+          "markdownDescription": "**majorVersion** (integer) _optional_\n\nThe kubernetes major version, default to the major version which is set by helm."
         },
         "minorVersion": {
-          "type": "string",
+          "type": "integer",
           "description": "The kubernetes minor version, default to the minor version which is set by helm.",
-          "markdownDescription": "**minorVersion** (string) _optional_\n\nThe kubernetes minor version, default to the minor version which is set by helm."
+          "markdownDescription": "**minorVersion** (integer) _optional_\n\nThe kubernetes minor version, default to the minor version which is set by helm."
         },
         "apiVersions": {
           "type": "array",
@@ -856,9 +856,9 @@
           "markdownDescription": "**namespace** (string) _optional_\n\nThe namespace which release be installed to, default to `\"NAMESPACE\"`."
         },
         "revision": {
-          "type": "string",
+          "type": "integer",
           "description": "The revision of current build, default to 0.",
-          "markdownDescription": "**revision** (string) _optional_\n\nThe revision of current build, default to `0`."
+          "markdownDescription": "**revision** (integer) _optional_\n\nThe revision of current build, default to `0`."
         },
         "upgrade": {
           "type": "boolean",


### PR DESCRIPTION
The default example from the docs doesn't pass schema validation:
![image](https://github.com/helm-unittest/helm-unittest/assets/45714268/07eece79-a940-4a9e-8be9-a2178d08e9d8)

If you try to "fix" it, the plugin throws an error:
```yaml
release:
  revision: "1"
```
![image](https://github.com/helm-unittest/helm-unittest/assets/45714268/7b7ef7fc-7a57-4e56-be2d-2c7bf90e71ee)
