### PR TITLE
Eliminate dependency on GitHub API

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -67,32 +67,9 @@ verifySupported() {
 
 # getDownloadURL checks the latest available version.
 getDownloadURL() {
-  # Use the GitHub API to find the latest version for this project.
-  local latest_url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
-  if [ -z "$HELM_PLUGIN_UPDATE" ]; then
-    local version=$(git describe --tags --exact-match 2>/dev/null)
-    if [ -n "$version" ]; then
-      latest_url="https://api.github.com/repos/$PROJECT_GH/releases/tags/$version"
-    fi
-  fi
-  echo "Retrieving $latest_url"
-  if type "curl" >/dev/null 2>&1; then
-    DOWNLOAD_URL=$(curl -sL "$latest_url" | grep "$OS-$ARCH" | awk '/\"browser_download_url\":/{gsub(/[,\"]/,"", $2); print $2}' 2>/dev/null)
-    # Backward compatibility when arch type is not yet used.
-    if [ -z "$DOWNLOAD_URL" ]; then
-      echo "No download_url found only searching for $OS"
-      DOWNLOAD_URL=$(curl -sL "$latest_url" | grep "$OS" | awk '/\"browser_download_url\":/{gsub(/[,\"]/,"", $2); print $2}' 2>/dev/null)
-    fi
-    PROJECT_CHECKSUM=$(curl -sL "$latest_url" | grep "checksum" | awk '/\"browser_download_url\":/{gsub(/[,\"]/,"", $2); print $2}' 2>/dev/null)
-  elif type "wget" >/dev/null 2>&1; then
-    DOWNLOAD_URL=$(wget -q -O - "$latest_url" | grep "$OS-$ARCH" | awk '/\"browser_download_url\":/{gsub(/[,\"]/,"", $2); print $2}' 2>/dev/null)
-    # Backward compatibility when arch type is not yet used.
-    if [ -z "$DOWNLOAD_URL" ]; then
-      echo "No download_url found only searching for $OS"
-      DOWNLOAD_URL=$(wget -q -O - "$latest_url" | grep "$OS" | awk '/\"browser_download_url\":/{gsub(/[,\"]/,"", $2); print $2}' 2>/dev/null)
-    fi
-    PROJECT_CHECKSUM=$(wget -q -O - "$latest_url" | grep "checksum" | awk '/\"browser_download_url\":/{gsub(/[,\"]/,"", $2); print $2}' 2>/dev/null)
-  fi
+  local version
+  version="$(git describe --tags --abbrev=0)"
+  DOWNLOAD_URL="https://github.com/helm-unittest/helm-unittest/releases/download/${version}/helm-unittest-${OS}-${ARCH}-${version#v}.tgz"
 }
 
 # downloadFile downloads the latest binary package and also the checksum


### PR DESCRIPTION
Helm has already cloned the repo at the appropriate revision by the time the hook is executed, so we don't actually need to use the GitHub API to figure out the right tag, or to generate the download URL (since it is deterministic).

The only disadvantage to doing things this way is we don't get the file checksum. However, having the checksum adds no security since it is retrieved from the same source as the file itself, so if TLS encryption was defeated, the checksum could be modified as well.

Fixes https://github.com/helm-unittest/helm-unittest/issues/181.

Test:

```
% h plugin install https://github.com/raxod502-plaid/helm-unittest --version rr-no-github-api
Support macos-arm64
Downloading https://github.com/helm-unittest/helm-unittest/releases/download/v0.3.3/helm-unittest-macos-arm64-0.3.3.tgz to location /tmp/_dist/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 19.5M  100 19.5M    0     0  6376k      0  0:00:03  0:00:03 --:--:-- 9279k
No Checksum validated.
Preparing to install into /Users/rrosborough/Library/helm/plugins/helm-unittest
helm-unittest installed into /Users/rrosborough/Library/helm/plugins/helm-unittest
Running chart unittest written in YAML.
```