### PR TITLE
Correct failed_template to also work when empty documents are found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ defined in test suite files.
 ```
       --color                  enforce printing colored output even stdout is not a tty. Set to false to disable color
       --strict                 strict parse the testsuites (default false)
+  -d, --debug                  enable debug logging (default false)
   -v, --values stringArray     absolute or glob paths of values files location to override helmchart values
   -f, --file stringArray       glob paths of test files location, default to tests\*_test.yaml (default [tests\*_test.yaml])
   -q, --failfast               direct quit testing, when a test is failed (default false)
@@ -133,7 +134,7 @@ Now JsonPath is supported for mappings and arrays.
 This makes it possible to find items in an array, based on JsonPath.
 For more detail on the [`jsonPath`](https://github.com/vmware-labs/yaml-jsonpath#syntax) syntax.
 
-Due to the change to JsonPath, the map keys in `path` containing periods (`.`) are now supported with the use of `""`:
+Due to the change to JsonPath, the map keys in `path` containing periods (`.`) or special characters (`/`) are now supported with the use of `""`:
 
 ```yaml
 - equal:

--- a/pkg/unittest/validators/failed_template_validator.go
+++ b/pkg/unittest/validators/failed_template_validator.go
@@ -43,12 +43,11 @@ func (a FailedTemplateValidator) Validate(context *ValidateContext) (bool, []str
 		return false, splitInfof(errorFormat, -1, err.Error())
 	}
 
-	validateSuccess := false
+	validateSuccess := true
 	validateErrors := make([]string, 0)
 
 	if context.RenderError != nil {
 
-		validateSuccess = true
 		if reflect.DeepEqual(a.ErrorMessage, context.RenderError.Error()) == context.Negative {
 			validateSuccess = false
 			errorMessage := a.failInfo(context.RenderError.Error(), -1, context.Negative)
@@ -56,6 +55,7 @@ func (a FailedTemplateValidator) Validate(context *ValidateContext) (bool, []str
 		}
 
 	} else {
+
 		for idx, manifest := range manifests {
 			actual := manifest[common.RAW]
 
@@ -67,6 +67,12 @@ func (a FailedTemplateValidator) Validate(context *ValidateContext) (bool, []str
 			}
 
 			validateSuccess = determineSuccess(idx, validateSuccess, true)
+		}
+
+		if len(manifests) == 0 && !context.Negative {
+			validateSuccess = false
+			errorMessage := a.failInfo("No failed document", -1, context.Negative)
+			validateErrors = append(validateErrors, errorMessage...)
 		}
 	}
 

--- a/pkg/unittest/validators/failed_template_validator_test.go
+++ b/pkg/unittest/validators/failed_template_validator_test.go
@@ -39,6 +39,35 @@ func TestFailedTemplateValidatorWhenNegativeAndOk(t *testing.T) {
 	assert.Equal(t, []string{}, diff)
 }
 
+func TestFailedTemplateValidatorWhenEmptyFail(t *testing.T) {
+	validator := FailedTemplateValidator{"A field should not be required"}
+	pass, diff := validator.Validate(&ValidateContext{
+		Docs:     []common.K8sManifest{},
+		Negative: false,
+		Index:    -1,
+	})
+
+	assert.False(t, pass)
+	assert.Equal(t, []string{
+		"Expected to equal:",
+		"	A field should not be required",
+		"Actual:",
+		"	No failed document",
+	}, diff)
+}
+
+func TestFailedTemplateValidatorWhenEmptyNegativeAndOk(t *testing.T) {
+	validator := FailedTemplateValidator{"A field should not be required"}
+	pass, diff := validator.Validate(&ValidateContext{
+		Docs:     []common.K8sManifest{},
+		Negative: true,
+		Index:    -1,
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
 func TestFailedTemplateValidatorWhenFail(t *testing.T) {
 	manifest := makeManifest(failedTemplate)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=helm-unittest
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=helm-unittest
-sonar.projectVersion=0.3.4
+sonar.projectVersion=0.4.0
  
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # Define all sources and exclude test-, and vendor files.


### PR DESCRIPTION
- Correct failed_template to also work when empty documents are found (resolves #191)
- Correct missing flags in README.md