### PR TITLE
Correct snapshot_validator to also work when empty documents are found.

### DIFF
--- a/pkg/unittest/validators/snapshot_validator.go
+++ b/pkg/unittest/validators/snapshot_validator.go
@@ -41,7 +41,7 @@ func (v MatchSnapshotValidator) Validate(context *ValidateContext) (bool, []stri
 		return false, splitInfof(errorFormat, -1, err.Error())
 	}
 
-	validateSuccess := false
+	validateSuccess := true
 	validateErrors := make([]string, 0)
 
 	for idx, manifest := range manifests {


### PR DESCRIPTION
Related to https://github.com/helm-unittest/helm-unittest/pull/198
Fixes https://github.com/helm-unittest/helm-unittest/issues/191

I need the same fix for `snapshot_validator` since it's failing when templates are returning empty string (which is the intended output sometimes).