### PR TITLE
Allow array for jsonpath in path

### DIFF
--- a/pkg/unittest/valueutils/valueutils_test.go
+++ b/pkg/unittest/valueutils/valueutils_test.go
@@ -17,6 +17,7 @@ func TestGetValueOfSetPathWithSingleResults(t *testing.T) {
 			"e.f": "false",
 			"g":   map[string]interface{}{"h": "\"quotes\""},
 			"i":   []interface{}{map[string]interface{}{"i1": "1"}, map[string]interface{}{"i2": "2"}},
+			"j":   []interface{}{map[string]interface{}{"k": "1"}, map[string]interface{}{"k": "2"}},
 		},
 	}
 
@@ -29,6 +30,7 @@ func TestGetValueOfSetPathWithSingleResults(t *testing.T) {
 		"a.g.h":                 "\"quotes\"",
 		"":                      data,
 		"a.i[?(@.i1 == \"1\")]": map[string]interface{}(map[string]interface{}{"i1": "1"}),
+		"a.j[*].k":              []interface{}{"1", "2"},
 	}
 
 	for path, expect := range expectionsMapping {


### PR DESCRIPTION
I recently tried to write a test that checks if a particular volume name appears in the deployment manifest. Here is a simplified version of my template:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
spec:
  replicas: 1
  selector:
    matchLabels:
      component: test
  template:
    metadata:
      labels:
        component: test
    spec:
      containers:
        - name: test
          image: test
          volumeMounts:
            - name: test-volume
              mountPath: /test-data
      volumes:
        - name: test-volume-1
          persistentVolumeClaim:
            claimName: test-pvc-1
        - name: test-volume-2
          persistentVolumeClaim:
            claimName: test-pvc-2
```

Here is the test I was trying:

```
suite: jsonpath test
tests:
  - it: Mounts required PVCs
    asserts:
      - contains:
          path: spec.template.spec.volumes[*].name
          content: test-volume-1
```

To which I got an error saying:

```
Error:
        expect 'spec.template.spec.volumes[*].name' to be an array, got:
        test-volume-1
```

`spec.template.spec.volumes[*].name` seems like a valid jsonpath to me, so I would expect it to return an array of volume names and `contains` should be able to apply the assert. But this does not seem to be the case, which is surprising.

With this MR I am trying to add support for my use case if this makes sense?