### PR TITLE
Added a parameter to render all templates to a directory

### DIFF
--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -25,6 +25,7 @@ type testOptions struct {
 	valuesFiles    []string
 	outputFile     string
 	outputType     string
+	renderPath     string
 }
 
 var testConfig = testOptions{}
@@ -82,6 +83,7 @@ details about how to write tests.
 			TestFiles:      testConfig.testFiles,
 			ValuesFiles:    testConfig.valuesFiles,
 			OutputFile:     testConfig.outputFile,
+			RenderPath:     testConfig.renderPath,
 		}
 
 		log.SetFormatter(&log.TextFormatter{
@@ -159,5 +161,10 @@ func init() {
 	cmd.PersistentFlags().BoolVarP(
 		&testConfig.debugLogging, "debug", "d", false,
 		"enable debug logging",
+	)
+
+	cmd.PersistentFlags().StringVarP(
+		&testConfig.renderPath, "render-path", "r", "",
+		"render-path render the templates to this directory, for debugging purposes",
 	)
 }

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -79,7 +79,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -106,7 +106,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -138,7 +138,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -163,7 +163,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -192,7 +192,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, false, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, false, "", &results.TestJobResult{})
 	// Write Buffer
 
 	a := assert.New(t)
@@ -222,7 +222,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 	// Write Buffer
 
 	a := assert.New(t)
@@ -249,7 +249,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -278,7 +278,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(fmt.Sprintf(manifest, file.Name())), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -305,7 +305,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -327,7 +327,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -351,7 +351,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -377,7 +377,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -409,7 +409,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -432,7 +432,7 @@ asserts:
 	var tj TestJob
 	err := yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -455,7 +455,7 @@ asserts:
 	var tj TestJob
 	yaml.Unmarshal([]byte(manifest), &tj)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -87,6 +87,7 @@ type TestRunner struct {
 	TestFiles        []string
 	ValuesFiles      []string
 	OutputFile       string
+	RenderPath       string
 	suiteCounting    testUnitCountingWithSnapshotFailed
 	testCounting     testUnitCounting
 	chartCounting    testUnitCounting
@@ -201,7 +202,7 @@ func (tr *TestRunner) runV3SuitesOfChart(suites []*TestSuite, chartPath string) 
 			continue
 		}
 
-		result := suite.RunV3(chartPath, snapshotCache, tr.Failfast, &results.TestSuiteResult{})
+		result := suite.RunV3(chartPath, snapshotCache, tr.Failfast, tr.RenderPath, &results.TestSuiteResult{})
 		chartPassed = chartPassed && result.Passed
 		tr.handleSuiteResult(result)
 		tr.testResults = append(tr.testResults, result)

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -81,6 +81,7 @@ func (s *TestSuite) RunV3(
 	chartPath string,
 	snapshotCache *snapshot.Cache,
 	failfast bool,
+	renderPath string,
 	result *results.TestSuiteResult,
 ) *results.TestSuiteResult {
 	s.polishTestJobsPathInfo()
@@ -92,6 +93,7 @@ func (s *TestSuite) RunV3(
 		chartPath,
 		snapshotCache,
 		failfast,
+		renderPath,
 	)
 
 	result.CountSnapshot(snapshotCache)
@@ -175,6 +177,7 @@ func (s *TestSuite) runV3TestJobs(
 	chartPath string,
 	cache *snapshot.Cache,
 	failfast bool,
+	renderPath string,
 ) (bool, []*results.TestJobResult) {
 	suitePass := false
 	jobResults := make([]*results.TestJobResult, len(s.Tests))
@@ -185,7 +188,7 @@ func (s *TestSuite) runV3TestJobs(
 		chart, _ := v3loader.Load(chartPath)
 		log.SetOutput(os.Stdout)
 
-		jobResult := testJob.RunV3(chart, cache, failfast, &results.TestJobResult{Index: idx})
+		jobResult := testJob.RunV3(chart, cache, failfast, renderPath, &results.TestJobResult{Index: idx})
 		jobResults[idx] = jobResult
 
 		if idx == 0 {

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -139,7 +139,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_noasserts_template_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, false, "validate empty asserts", 1, 0, 0, 0, 0)
 }
@@ -178,7 +178,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_multiple_template_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "validate metadata", 1, 5, 5, 0, 0)
 }
@@ -202,7 +202,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_suite_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite name", 1, 2, 2, 0, 0)
 }
@@ -238,7 +238,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_suite_override_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite name", 1, 1, 1, 0, 0)
 }
@@ -261,7 +261,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_failed_suite_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, false, "test suite name", 1, 0, 0, 0, 0)
 }
@@ -284,7 +284,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_subfolder_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3WithSubFolderChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3WithSubFolderChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite name", 1, 2, 2, 0, 0)
 }
@@ -306,7 +306,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_subchart_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3WithSubChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3WithSubChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite with subchart", 1, 1, 1, 0, 0)
 }
@@ -336,7 +336,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_subchartwithalias_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3WithSubChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3WithSubChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite with subchart", 2, 2, 2, 0, 0)
 }
@@ -358,7 +358,7 @@ tests:
 	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_nameoverride_failed_suite_test.yaml"), false)
-	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(testV3BasicChart, cache, true, "", &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite name too long", 1, 0, 0, 0, 0)
 }


### PR DESCRIPTION
# Description

This PR adds a command line parameter `--render-path` that will make helm-unittest render test templates to the given directory.

This is very useful for debugging the templates since sometimes when tests fail there isn't much information in the error message, and it could be due to a silly mistake (for example an extra space).