### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: "helm-unittest"
+  name: "helm unittest"
+  description: "Runs Helm unit tests."
+  language: "script"
+  entry: "/usr/bin/env helm"
+  args: ["unittest", "."]
+  files: "^Chart.yaml$"
+  pass_filenames: false


### PR DESCRIPTION
Hello,

I would like to propose to add a pre-commit hooks file to the repo, so people can easily import the hook in their pre-commit configuration.

Thx,
Fred