### PR TITLE
Support Windows 11 Pro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ dist:
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o untt.exe -ldflags $(LDFLAGS) ./cmd/helm-unittest
 	tar -zcvf $(DIST)/helm-unittest-windows-amd64-$(VERSION).tgz untt.exe README.md LICENSE plugin.yaml
 	shasum -a 256 -b $(DIST)/* > $(DIST)/helm-unittest-checksum.sha
+	tar -zcvf $(DIST)/helm-unittest-windows_nt-amd64-$(VERSION).tgz untt.exe README.md LICENSE plugin.yaml
+	shasum -a 256 -b $(DIST)/* > $(DIST)/helm-unittest-checksum.sha
 
 .PHONY: bootstrap
 bootstrap:

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -52,7 +52,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="linux-arm64\nlinux-amd64\nmacos-amd64\nwindows-amd64\nmacos-arm64"
+  local supported="linux-arm64\nlinux-amd64\nmacos-amd64\nwindows-amd64\nwindows_nt-amd64\nmacos-arm64"
   if ! echo "$supported" | grep -q "$OS-$ARCH"; then
     echo "No prebuild binary for $OS-$ARCH."
     exit 1


### PR DESCRIPTION
Windows 11 Pro identifies as windows_nt-amd64, so we need to also create a helm-unittest-windows_nt-amd64-$(VERSION).tgz for everything to work.

```
PS: 12/20/2023 09:37:43>helm plugin install https://github.com/helm-unittest/helm-unittest
>>
No prebuild binary for windows_nt-amd64.
Failed to install helm-unittest
For support, go to https://github.com/kubernetes/helm
Error: plugin install hook for "unittest" exited with error
````

If you want it to work retroactively for version v0.3.6 you will need to retroactively edit the helm-unittest-checksum.sha file and duplicate the file helm-unittest-windows-amd64-0.3.6.tgz to helm-unittest-windows_nt-amd64-0.3.6.tgz 
https://github.com/fcbry/helm-unittest/releases/tag/v0.3.6



