### PR TITLE
Correct containsDocumentValidator to resolve antonym validations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 0.4.0 / 
 ==================
-- Added DocumentSelecter
+- Added DocumentSelecter (credits @jonathon-mcnabb, resolve #179)
+- Remove trim copying logging (resolves #237)
+- Correct containsDocument validation (resolves #)
+- Update packages to latest patch versions
+- Update json schema (credits @justusbunsi)
+- Update documentation (credits @atombrella)
 
 0.3.6 / 2023-11-04
 ==================
@@ -11,7 +16,7 @@
 - Optimize installation (resolves #176, resolves #214, resolves #225)
 - Added templated Test Suites, to make re-usable tests possible (credits @hanseltime, resolves #57, resolves #186)
 - Update packages to latest patch versions
-- Update documenation
+- Update documentation
 
 0.3.5 / 2023-09-14
 ==================

--- a/pkg/unittest/validators/contains_document_validator.go
+++ b/pkg/unittest/validators/contains_document_validator.go
@@ -77,17 +77,20 @@ func (v ContainsDocumentValidator) Validate(context *ValidateContext) (bool, []s
 	for idx, manifest := range manifests {
 		singleSuccess := v.validateManifest(manifest)
 
-		if v.Any && singleSuccess && !context.Negative {
-			return (singleSuccess && !context.Negative), []string{}
-		}
-
-		validateSuccess = determineSuccess(idx, validateSuccess, singleSuccess && !context.Negative)
-
-		if !singleSuccess && !context.Negative ||
-			singleSuccess && context.Negative {
+		if singleSuccess == context.Negative {
+			singleSuccess = false
 			errorMessage := v.failInfo(v.Kind, idx, context.Negative)
 			validateErrors = append(validateErrors, errorMessage...)
+		} else {
+			singleSuccess = true
+			if v.Any {
+				validateSuccess = true
+				validateErrors = []string{}
+				continue
+			}
 		}
+
+		validateSuccess = determineSuccess(idx, validateSuccess, singleSuccess)
 	}
 
 	if len(manifests) == 0 && !context.Negative {

--- a/pkg/unittest/validators/contains_document_validator_test.go
+++ b/pkg/unittest/validators/contains_document_validator_test.go
@@ -180,6 +180,25 @@ func TestContainsDocumentValidatorNoNamespaceWhenOk(t *testing.T) {
 	assert.Equal(t, []string{}, diff)
 }
 
+func TestContainsDocumentValidatorNoNamespaceWhenNegativeOk(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"InvalidService",
+		"v1",
+		"foo",
+		"",
+		true,
+	}
+
+	pass, diff := validator.Validate(&ValidateContext{
+		Index:    -1,
+		Docs:     []common.K8sManifest{makeManifest(docToTestContainsDocument1)},
+		Negative: true,
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
 func TestContainsDocumentValidatorNoNameNamespaceWhenOk(t *testing.T) {
 	validator := ContainsDocumentValidator{
 		"Service",


### PR DESCRIPTION
Fix containsDocument validator when negative:true is used (resolves #239)
Added tests for validation.