### PR TITLE
fix: global value leak

### DIFF
--- a/internal/common/utilities.go
+++ b/internal/common/utilities.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"strings"
 
 	yaml "gopkg.in/yaml.v3"
 )
@@ -16,4 +17,14 @@ func TrustedMarshalYAML(d interface{}) string {
 		panic(err)
 	}
 	return byteBuffer.String()
+}
+
+// TrustedUnmarshalYAML unmarshal yaml without error returned, if an error happens it panics
+func TrustedUnmarshalYAML(d string) map[string]interface{} {
+	parsedYaml := K8sManifest{}
+	yamlDecoder := yaml.NewDecoder(strings.NewReader(d))
+	if err := yamlDecoder.Decode(&parsedYaml); err != nil {
+		panic(err)
+	}
+	return parsedYaml
 }

--- a/pkg/unittest/.snapshots/TestV3RunnerOkGlobalDoubleWithPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkGlobalDoubleWithPassedTests
@@ -4,11 +4,12 @@
 
  PASS  	../../test/data/v3/global-double-setting/tests/configmap_test.yaml
  PASS  	../../test/data/v3/global-double-setting/tests/deployment_test.yaml
+ PASS  cat deployment testSuite	../../test/data/v3/global-double-setting/tests/cat_deployment_test.yaml
 
 
 Charts:      1 passed, 1 total
-Test Suites: 2 passed, 2 total
-Tests:       3 passed, 3 total
+Test Suites: 3 passed, 3 total
+Tests:       5 passed, 5 total
 Snapshot:    0 passed, 0 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/helm-unittest/helm-unittest/internal/common"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/results"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
 	"gopkg.in/yaml.v3"
@@ -210,15 +211,9 @@ func (s *TestSuite) polishTestJobsPathInfo() {
 		s.polishChartSettings(test)
 
 		// Make deep clone of global set
-		tmp, err := yaml.Marshal(s.Set)
-		if err != nil {
-			log.Fatal(err)
-		}
+		tmp := common.TrustedMarshalYAML(s.Set)
 
-		err = yaml.Unmarshal(tmp, &test.globalSet)
-		if err != nil {
-			log.Fatal(err)
-		}
+		test.globalSet = common.TrustedUnmarshalYAML(tmp)
 
 		if len(s.Values) > 0 {
 			test.Values = append(test.Values, s.Values...)

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -209,7 +209,16 @@ func (s *TestSuite) polishTestJobsPathInfo() {
 		s.polishCapabilitiesSettings(test)
 		s.polishChartSettings(test)
 
-		test.globalSet = s.Set
+		// Make deep clone of global set
+		tmp, err := yaml.Marshal(s.Set)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = yaml.Unmarshal(tmp, &test.globalSet)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		if len(s.Values) > 0 {
 			test.Values = append(test.Values, s.Values...)

--- a/test/data/v3/global-double-setting/templates/cat_deployment.yaml
+++ b/test/data/v3/global-double-setting/templates/cat_deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    metadata:
+      labels:
+        - cat: dog
+        {{- if (.Values.env).testvalue }}
+        - testvalue: {{ .Values.env.testvalue }}
+        {{- end }}
+    

--- a/test/data/v3/global-double-setting/tests/cat_deployment_test.yaml
+++ b/test/data/v3/global-double-setting/tests/cat_deployment_test.yaml
@@ -1,0 +1,24 @@
+suite: cat deployment testSuite
+templates:
+  - templates/cat_deployment.yaml
+set:
+  env:
+    key: value
+
+tests:
+  - it: test sets value
+    set:
+      env:
+        testvalue: testvalue1
+    asserts:
+      - contains:
+          path: spec.template.metadata.labels
+          content:
+            testvalue: testvalue1
+
+  - it: test does not set testvalue, should be empty in deployment
+    asserts:
+      - notContains:
+          path: spec.template.metadata.labels
+          content:
+            testvalue: testvalue1


### PR DESCRIPTION
Fixes #235 

The `globalSet` is being polluted due to the copy of reference. 
This fix uses `yaml.Marshal` and `yaml.Unmarshal` to create a deep clone of the global values.

The output from #235 is now: 

```
### Chart [ leak ] test/data/v3/leak/

 FAIL  test values      test/data/v3/leak/tests/leak_test.yaml
        - should have a default list with 1 element

                - asserts[0] `lengthEqual` fail
                        Template:       leak/templates/configmap.yaml
                        DocumentIndex:  0
                        Error:
                                unknown parameter data.foo
                                expected result does not match


Charts:      1 failed, 0 passed, 1 total
Test Suites: 1 failed, 0 passed, 1 total
Tests:       1 failed, 2 passed, 3 total
Snapshot:    0 passed, 0 total
Time:        8.056ms
``` 

As expected :) 