### PR TITLE
fix empty document selector

### DIFF
--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -105,7 +105,7 @@ func (a *Assertion) Assert(
 }
 
 func (a *Assertion) determineDocumentIndex(templatesResult map[string][]common.K8sManifest) error {
-	if a.DocumentSelector != nil {
+	if a.DocumentSelector != nil && a.DocumentSelector.Path != "" {
 		idx, err := a.DocumentSelector.FindDocumentsIndex(templatesResult)
 		if err != nil {
 			return err


### PR DESCRIPTION
The test suite code creates an empty document selector by default (that is, one where DocumentSelector exists but DocumentSelector.Path is an empty string), causing bugs with referencing dependency packages. This commit resolves that.