### PR TITLE
bug(issue-316): containsDocument fix negative context support

### DIFF
--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithFailedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithFailedTests
@@ -45,7 +45,7 @@
 			Template:	basic/templates/rbac.yaml
 			DocumentIndex:	1
 			Expected to contain document:
-				Kind = ClusterRole, apiVersion = rbac.authorization.k8s.io/v1, Name = , Namespace =
+				Kind = ClusterRole, apiVersion = rbac.authorization.k8s.io/v1
  FAIL  test autoscaling	../../test/data/v3/basic/tests_failed/nofile_test.yaml
 	- should use GLOBAL scaling config when release autoscaling AND Global autoscaling are enabled
 

--- a/pkg/unittest/validators/contains_document_validator_test.go
+++ b/pkg/unittest/validators/contains_document_validator_test.go
@@ -28,7 +28,7 @@ var docToTestContainsDocument3 = `
 apiVersion: v1
 kind: Service
 metadata:
-    name: bar	
+    name: bar
 `
 
 var docToTestContainsDocument4 = `
@@ -60,21 +60,49 @@ func TestContainsDocumentValidatorWhenEmptyNOk(t *testing.T) {
 }
 
 func TestContainsDocumentValidatorNegativeWhenEmptyOk(t *testing.T) {
-	validator := ContainsDocumentValidator{
-		Kind:       "Service",
-		APIVersion: "v1",
-		Name:       "bar",
-		Namespace:  "foo",
-		Any:        true,
+	tests := []struct {
+		name      string
+		validator ContainsDocumentValidator
+		docs      []common.K8sManifest
+		expected  []string
+	}{
+		{
+			name: "should not fail with empty manifest and negative context",
+			validator: ContainsDocumentValidator{
+				Kind:       "Deployment",
+				APIVersion: "v1",
+				Name:       "bar",
+				Namespace:  "foo",
+				Any:        true,
+			},
+			docs:     []common.K8sManifest{},
+			expected: []string{},
+		},
+		{
+			name: "should not fail with multiple manifest and negative context",
+			validator: ContainsDocumentValidator{
+				Kind:       "Deployment",
+				APIVersion: "v1",
+				Name:       "bar",
+				Namespace:  "foo",
+				Any:        true,
+			},
+			docs: []common.K8sManifest{makeManifest(docToTestContainsDocument1),
+				makeManifest(docToTestContainsDocument2)},
+			expected: []string{},
+		},
 	}
-	pass, diff := validator.Validate(&ValidateContext{
-		Index:    -1,
-		Docs:     []common.K8sManifest{},
-		Negative: true,
-	})
 
-	assert.False(t, pass)
-	assert.Equal(t, []string{}, diff)
+	for _, test := range tests {
+		pass, diff := test.validator.Validate(&ValidateContext{
+			Index:    -1,
+			Docs:     test.docs,
+			Negative: true,
+		})
+
+		assert.True(t, pass)
+		assert.Equal(t, test.expected, diff)
+	}
 }
 
 func TestContainsDocumentValidatorWhenNotAllDocumentsAreOk(t *testing.T) {
@@ -250,10 +278,10 @@ func TestContainsDocumentValidatorNoNameNamespaceWhenNegativeNOk(t *testing.T) {
 	assert.Equal(t, []string{
 		"DocumentIndex:\t0",
 		"Expected NOT to contain document:",
-		"\tKind = Service, apiVersion = v1, Name = , Namespace =",
+		"\tKind = Service, apiVersion = v1",
 		"DocumentIndex:\t1",
 		"Expected NOT to contain document:",
-		"\tKind = Service, apiVersion = v1, Name = , Namespace =",
+		"\tKind = Service, apiVersion = v1",
 	}, diff)
 }
 
@@ -330,7 +358,7 @@ func TestContainsDocumentValidatorFail(t *testing.T) {
 			expected: []string{
 				"DocumentIndex:\t0",
 				"Expected to contain document:",
-				"\tKind = Service, apiVersion = apps/v1, Name = foo, Namespace =",
+				"\tKind = Service, apiVersion = apps/v1, Name = foo",
 			},
 		},
 		{
@@ -347,7 +375,7 @@ func TestContainsDocumentValidatorFail(t *testing.T) {
 			expected: []string{
 				"DocumentIndex:\t0",
 				"Expected to contain document:",
-				"\tKind = Service, apiVersion = apps/v1, Name = , Namespace = bar",
+				"\tKind = Service, apiVersion = apps/v1, Namespace = bar",
 			},
 		},
 	}

--- a/pkg/unittest/validators/contains_document_validator_test.go
+++ b/pkg/unittest/validators/contains_document_validator_test.go
@@ -38,7 +38,7 @@ metadata:
     namespace: foo
 `
 
-func TestContainsDocumentValidatorWhenEmptyNOk(t *testing.T) {
+func TestContainsDocumentValidatorWhenEmptyOk(t *testing.T) {
 	validator := ContainsDocumentValidator{
 		Kind:       "Service",
 		APIVersion: "v1",
@@ -59,7 +59,7 @@ func TestContainsDocumentValidatorWhenEmptyNOk(t *testing.T) {
 	}, diff)
 }
 
-func TestContainsDocumentValidatorNegativeWhenEmptyOk(t *testing.T) {
+func TestContainsDocumentValidatorNegativeOk(t *testing.T) {
 	tests := []struct {
 		name      string
 		validator ContainsDocumentValidator

--- a/test/data/v3/basic/tests/ingress_test.yaml
+++ b/test/data/v3/basic/tests/ingress_test.yaml
@@ -30,6 +30,9 @@ tests:
               servicePort: 12345
       - notExists:
           path: spec.tls
+      - containsDocument:
+          kind: Ingress
+          apiVersion: extensions/v1beta1
 
   - it: should set annotations if given
     set:
@@ -92,7 +95,10 @@ tests:
 
   - it: should render nothing if not enabled
     asserts:
+      - containsDocument:
+          kind: Ingress
+          apiVersion: extensions/v1beta1
+        not: true
       - hasDocuments:
           count: 0
       - matchSnapshot: {}
-


### PR DESCRIPTION
issue https://github.com/helm-unittest/helm-unittest/issues/316

- Covered with unit tests
- Covered with end-2-end tests
- Output no longer contains empty attributes before `Kind = ScaledObject, apiVersion = keda.sh/v1alpha1, Name = , Namespace =` now `Kind = ScaledObject, apiVersion = keda.sh/v1alpha1`