### PR TITLE
bug: `notLengthEqual` assertion is never satisfied

### DIFF
--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithFailedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithFailedTests
@@ -298,6 +298,20 @@
 				  name: basic
 				  ports:
 				    - containerPort: null
+
+		- asserts[15] `lengthEqual` fail
+			Template:	basic/templates/deployment.yaml
+			DocumentIndex:	0
+			Error:
+				count doesn't match as expected. expected: 10 actual: 1
+			DocumentIndex:	1
+			Error:
+				count doesn't match as expected. expected: 10 actual: 1
+				expected result does not match
+
+		- asserts[16] `notLengthEqual` fail
+			Template:	basic/templates/deployment.yaml
+				expected result does not match
  FAIL  test deployment that would be fail as it is missing the include	../../test/data/v3/basic/tests_failed/include_deployment_test.yaml
 	- should not render
 		Error: template: basic/templates/deployment.yaml:13:24: executing "basic/templates/deployment.yaml" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: no template "basic/templates/configmap.yaml" associated with template "gotpl"

--- a/pkg/unittest/validators/length_equal_document_validator.go
+++ b/pkg/unittest/validators/length_equal_document_validator.go
@@ -123,6 +123,9 @@ func (v LengthEqualDocumentsValidator) Validate(context *ValidateContext) (bool,
 	if validateSuccess == context.Negative {
 		validateSuccess = false
 		validateErrors = append(validateErrors, "\texpected result does not match")
+	} else {
+		validateSuccess = true
+		validateErrors = make([]string, 0)
 	}
 
 	return validateSuccess, validateErrors

--- a/pkg/unittest/validators/length_equal_document_validator_test.go
+++ b/pkg/unittest/validators/length_equal_document_validator_test.go
@@ -84,6 +84,22 @@ func TestLengthEqualDocumentsValidatorOk_Single2(t *testing.T) {
 	assert.Equal(t, []string{}, diff)
 }
 
+func TestLengthEqualDocumentsValidatorNegativeOk_Single(t *testing.T) {
+	manifest := makeManifest(testDocLengthEqual1)
+
+	validator := LengthEqualDocumentsValidator{
+		Path:  "spec.tls",
+		Count: 2,
+	}
+	pass, diff := validator.Validate(&ValidateContext{
+		Docs:     []common.K8sManifest{manifest},
+		Negative: true,
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
 func TestLengthEqualDocumentsValidatorOk_Multi(t *testing.T) {
 	manifest := makeManifest(testDocLengthEqual3_Success)
 
@@ -98,7 +114,7 @@ func TestLengthEqualDocumentsValidatorOk_Multi(t *testing.T) {
 	assert.Equal(t, []string{}, diff)
 }
 
-func TestLengthEqualDocumentsValidatorNegativeOk_Multi(t *testing.T) {
+func TestLengthEqualDocumentsValidatorNegativeFail_Multi(t *testing.T) {
 	manifest := makeManifest(testDocLengthEqual3_Success)
 
 	validator := LengthEqualDocumentsValidator{
@@ -133,7 +149,7 @@ func TestLengthEqualDocumentsValidatorNegativeFail_Single(t *testing.T) {
 
 	validator := LengthEqualDocumentsValidator{
 		Path:  "spec.tls",
-		Count: 1,
+		Count: 2,
 	}
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs:     []common.K8sManifest{manifest},
@@ -141,7 +157,7 @@ func TestLengthEqualDocumentsValidatorNegativeFail_Single(t *testing.T) {
 	})
 
 	assert.False(t, pass)
-	assert.Equal(t, []string{"DocumentIndex:\t0", "Error:", "\tcount doesn't match as expected. expected: 1 actual: 2"}, diff)
+	assert.Equal(t, []string{"\texpected result does not match"}, diff)
 }
 
 func TestLengthEqualDocumentsValidatorFail_Multi(t *testing.T) {

--- a/test/data/v3/basic/tests/deployment_test.yaml
+++ b/test/data/v3/basic/tests/deployment_test.yaml
@@ -61,3 +61,9 @@ tests:
           count: 2
       - matchSnapshot:
           path: spec
+      - lengthEqual:
+          path:  spec.template.spec.containers
+          count: 1
+      - notLengthEqual:
+          path: spec.template.spec.containers
+          count: 10

--- a/test/data/v3/basic/tests_failed/deployment_test.yaml
+++ b/test/data/v3/basic/tests_failed/deployment_test.yaml
@@ -50,3 +50,9 @@ tests:
           path: spec.template.spec.containers
           content: 'foo'
           count: 1234567890 # or 6.8 or -10 or 0
+      - lengthEqual:
+          path:  spec.template.spec.containers
+          count: 10
+      - notLengthEqual:
+          path: spec.template.spec.containers
+          count: 1


### PR DESCRIPTION
Due to an issue in the validator implementation it is impossible to satisfy the `notLengthEqual` assertion. This PR fix the validator and adopted the related tests.

If `context.Negative` is `true` the return value `validateSuccess` is always `false` either due to the original validation or it will be set to `false` in the following code snippet:
```
	if validateSuccess == context.Negative {
		validateSuccess = false
		validateErrors = append(validateErrors, "\texpected result does not match")
	}
```