### PR TITLE
doc(Document.mx): fix typo

### DIFF
--- a/DOCUMENT.md
+++ b/DOCUMENT.md
@@ -176,7 +176,7 @@ tests:
         documentIndex: 0
 ```
 
-The assertion is defined with the assertion type as the key and its parameters as value, there can be only one assertion type key exists in assertion definition object. And there are three more options can be set at root of assertion definition:
+The assertion is defined with the assertion type as the key and its parameters as value, there can be only one assertion type key exists in assertion definition object. And there are four more options can be set at root of assertion definition:
 
 - **not**: *bool, optional*. Set to `true` to assert contrarily, default to `false`. The second assertion in the example above asserts that the service name is **NOT** *your-service*.
 


### PR DESCRIPTION
* Fix typo in the number of available options in assertion definition

## How to review?
* Check that the possibilities are: `not`, `template`, `documentIndex` and `documentSelector`