### PR TITLE
Fix failedTemplate properties

### DIFF
--- a/schema/helm-testsuite.json
+++ b/schema/helm-testsuite.json
@@ -756,9 +756,9 @@
                       "type": "object",
                       "description": "Assert the value of errorMessage is the same as the human readable template error.",
                       "markdownDescription": "**failedTemplate** (object)\n\nAssert the value of `errorMessage` is the same as the human readable template error.",
-                      "additionalProperties": false,
                       "oneOf": [
                         {
+                          "additionalProperties": false,
                           "properties": {
                             "errorMessage": {
                               "type": "string",
@@ -774,6 +774,7 @@
                           ]
                         },
                         {
+                          "additionalProperties": false,
                           "properties": {
                             "errorPattern": {
                               "type": "string",


### PR DESCRIPTION
We validate our Helm tests against the schema and face this issue:

```
foo.helmunit.yaml: fail: tests.0.asserts.0: Must validate one and only one schema (oneOf)
foo.helmunit.yaml: fail: tests.0.asserts.0.failedTemplate: Additional property errorMessage is not allowed
```

This PR should fix this.