### PR TITLE
issue-342: added examples for command when different arrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,5 +100,5 @@ test-docker: dockerimage ## Execute 'helm unittests' in container
 			--rm  $(DOCKER):$(VERSION) -f tests/*.yaml .;\
 	done
 
-test-local:
+test-basic:
 	@./untt -f 'tests/*.yaml' test/data/v3/basic

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: plugin-dir
-plugin-dir: 
+plugin-dir:
   HELM_3_PLUGINS := $(shell bash -c 'eval $$(helm env); echo $$HELM_PLUGINS')
   HELM_PLUGIN_DIR := $(HELM_3_PLUGINS)/helm-unittest
 
@@ -99,3 +99,6 @@ test-docker: dockerimage ## Execute 'helm unittests' in container
 			-v $(PROJECT_DIR)/test/data/v3/$${f}:/apps \
 			--rm  $(DOCKER):$(VERSION) -f tests/*.yaml .;\
 	done
+
+test-local:
+	@./untt -f 'tests/*.yaml' test/data/v3/basic

--- a/test/data/v3/basic/templates/deployment.yaml
+++ b/test/data/v3/basic/templates/deployment.yaml
@@ -73,3 +73,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.dbPort }}
+          command:
+            - ./execute
+            - --stderrthreshold=info
+            - --v=0
+      initContainers:
+        - name: "init-basic"
+          image: busybox:1.28
+          command: ['sh', '-c', "until nslookup google.com; sleep 2; done"]

--- a/test/data/v3/basic/tests/deployment_test.yaml
+++ b/test/data/v3/basic/tests/deployment_test.yaml
@@ -162,3 +162,9 @@ tests:
           path: spec.template.spec.initContainers[?(@.name == "init-basic")].command
           content:
             until nslookup google.com; sleep 2; done
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "init-basic")].command
+          content:
+            - sh
+            - -c
+          any: true

--- a/test/data/v3/basic/tests/deployment_test.yaml
+++ b/test/data/v3/basic/tests/deployment_test.yaml
@@ -137,3 +137,28 @@ tests:
       - notGreaterOrEqual:
           path: spec.template.spec.containers[?(@.name == "basic")].resources.requests.memory
           value: "101Mi"
+
+  - it: should validate command for container and init container
+    template: templates/deployment.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "basic")].command
+          value:
+            - ./execute
+            - --stderrthreshold=info
+            - --v=0
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "basic")].command
+          content:
+            --v=0
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name == "init-basic")].command
+          value:
+              - sh
+              - -c
+              - until nslookup google.com; sleep 2; done
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "init-basic")].command
+          content:
+            until nslookup google.com; sleep 2; done


### PR DESCRIPTION
Added tests to cover issue https://github.com/helm-unittest/helm-unittest/issues/342

Reproduced
![Screenshot 2024-08-29 at 08 35 02](https://github.com/user-attachments/assets/331958b1-8e0d-4d1e-86c0-9734cb4f6216)

Without `any:true` the contains only look for any match. With `any:true` the content does lookup for all matches 


Docs https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md