### PR TITLE
fix: bug with notFailedTemplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: plugin-dir
-plugin-dir: 
+plugin-dir:
   HELM_3_PLUGINS := $(shell bash -c 'eval $$(helm env); echo $$HELM_PLUGINS')
   HELM_PLUGIN_DIR := $(HELM_3_PLUGINS)/helm-unittest
 

--- a/pkg/unittest/validators/failed_template_validator.go
+++ b/pkg/unittest/validators/failed_template_validator.go
@@ -21,9 +21,11 @@ func (a FailedTemplateValidator) failInfo(actual interface{}, index int, not boo
 	customMessage := " to equal"
 	if a.ErrorPattern != "" {
 		customMessage = " to match"
+	} else if a.ErrorPattern + a.ErrorMessage == "" {
+		customMessage = " to throw"
 	}
 
-	message := cmp.Or(a.ErrorMessage, a.ErrorPattern)
+	message := cmp.Or(a.ErrorMessage, a.ErrorPattern, cmp.Or(fmt.Sprintf("%s", actual), "error"))
 
 	log.WithField("validator", "failed_template").Debugln("expected content:", message)
 	log.WithField("validator", "failed_template").Debugln("actual content:", actual)
@@ -76,16 +78,19 @@ func (a FailedTemplateValidator) validateManifests(manifests []common.K8sManifes
 		currentSuccess := false
 		actual := manifest[common.RAW]
 
+
 		if a == (FailedTemplateValidator{}) && !context.Negative {
-			// If the validator is empty and the context is not negative,
+			// If the validator is empty and the context is negative,
 			// continue to the next iteration without throwing an error.
 			continue
 		}
 
 		if a.ErrorPattern != "" {
 			currentSuccess, validateErrors = a.validateErrorPattern(actual, idx, context, currentSuccess, validateErrors)
-		} else {
+		} else if a.ErrorMessage != "" {
 			currentSuccess, validateErrors = a.validateErrorMessage(actual, idx, context, currentSuccess, validateErrors)
+		} else {
+			currentSuccess, validateErrors = a.validateNoError(actual, idx, context, currentSuccess, validateErrors)
 		}
 
 		validateSuccess = determineSuccess(idx, validateSuccess, currentSuccess)
@@ -125,6 +130,15 @@ func (a FailedTemplateValidator) validateErrorMessage(actual interface{}, idx in
 	} else {
 		validateSuccess = true
 	}
+	return validateSuccess, validateErrors
+}
 
+func (a FailedTemplateValidator) validateNoError(actual interface{}, idx int, context *ValidateContext, validateSuccess bool, validateErrors []string) (bool, []string) {
+	if actual != nil && context.Negative {
+		errorMessage := a.failInfo(actual, idx, context.Negative)
+		validateErrors = append(validateErrors, errorMessage...)
+	} else if actual == nil && context.Negative {
+		validateSuccess = true
+	}
 	return validateSuccess, validateErrors
 }

--- a/pkg/unittest/validators/failed_template_validator.go
+++ b/pkg/unittest/validators/failed_template_validator.go
@@ -21,7 +21,7 @@ func (a FailedTemplateValidator) failInfo(actual interface{}, index int, not boo
 	customMessage := " to equal"
 	if a.ErrorPattern != "" {
 		customMessage = " to match"
-	} else if a.ErrorPattern + a.ErrorMessage == "" {
+	} else if a.ErrorPattern+a.ErrorMessage == "" {
 		customMessage = " to throw"
 	}
 
@@ -58,6 +58,7 @@ func (a FailedTemplateValidator) Validate(context *ValidateContext) (bool, []str
 		validateErrors = append(validateErrors, errorMessage...)
 	} else if context.RenderError != nil {
 		if a.ErrorMessage != "" && reflect.DeepEqual(a.ErrorMessage, context.RenderError.Error()) == context.Negative && a != (FailedTemplateValidator{}) {
+			// TODO: this block not unit tested. Could be that behavior is wrong
 			errorMessage := a.failInfo(context.RenderError.Error(), -1, context.Negative)
 			validateErrors = append(validateErrors, errorMessage...)
 		} else {
@@ -77,7 +78,6 @@ func (a FailedTemplateValidator) validateManifests(manifests []common.K8sManifes
 	for idx, manifest := range manifests {
 		currentSuccess := false
 		actual := manifest[common.RAW]
-
 
 		if a == (FailedTemplateValidator{}) && !context.Negative {
 			// If the validator is empty and the context is negative,

--- a/pkg/unittest/validators/failed_template_validator_test.go
+++ b/pkg/unittest/validators/failed_template_validator_test.go
@@ -85,7 +85,7 @@ func TestFailedTemplateValidatorWhenEmptyAntonymAndError(t *testing.T) {
 	assert.Equal(t, []string{"DocumentIndex:\t0", "Expected NOT to throw:", "\tA field should not be required"}, diff)
 }
 
-func TestFailedTemplateValidatorWhenAntonymAndNoError(t *testing.T) {
+func TestFailedTemplateValidatorWhenEmptyAntonymAndNoError(t *testing.T) {
 	docToTestContainsValueOnly := `
 a:
   b:

--- a/test/data/v3/basic/tests/ingress_test.yaml
+++ b/test/data/v3/basic/tests/ingress_test.yaml
@@ -33,6 +33,7 @@ tests:
       - containsDocument:
           kind: Ingress
           apiVersion: extensions/v1beta1
+      - notFailedTemplate: {}
 
   - it: should set annotations if given
     set:


### PR DESCRIPTION
New release 0.6.0 throws an error

- Added helm chart test
- Added unit-test

The code is a bit confusing. For example `context.Negative` for `failedTeamplte is false` for `notFailedTemplate is true`. Probably wortht to rename it to IsAntonym or something...

Outside of the scope for this pull request but worth to understand where everything is correct there
```
} else if context.RenderError != nil {
		if a.ErrorMessage != "" && reflect.DeepEqual(a.ErrorMessage, context.RenderError.Error()) == context.Negative && a != (FailedTemplateValidator{}) {
			// TODO: this block not unit tested. Could be that behavior is wrong
			errorMessage := a.failInfo(context.RenderError.Error(), -1, context.Negative)
			validateErrors = append(validateErrors, errorMessage...)
		} else {
			validateSuccess = true
		}
	} 
```
The logic never executes, could be that behavior when error is rendereed is not correct. Will leave it for follow up