### PR TITLE
fix(issue-412): chart metadata override logic

### DIFF
--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
@@ -16,7 +16,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 10 passed, 10 total
-Tests:       25 passed, 25 total
+Tests:       28 passed, 28 total
 Snapshot:    4 passed, 4 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
@@ -16,7 +16,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 10 passed, 10 total
-Tests:       25 passed, 25 total
+Tests:       28 passed, 28 total
 Snapshot:    4 passed, 4 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithPassedTests
@@ -16,7 +16,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 10 passed, 10 total
-Tests:       25 passed, 25 total
+Tests:       28 passed, 28 total
 Snapshot:    4 passed, 4 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -41,6 +41,11 @@ func ParseTestSuiteFile(suiteFilePath, chartRoute string, strict bool, valueFile
 		// Ensure the part has data exclude whitespace, otherwise we can ignore the split
 		if len(strings.TrimSpace(part)) > 0 {
 			testSuite, suiteErr := createTestSuite(suiteFilePath, chartRoute, part, strict, valueFilesSet, false)
+			if testSuite != nil {
+				for _, test := range testSuite.Tests {
+					testSuite.polishChartSettings(test)
+				}
+			}
 			testSuites = append(testSuites, testSuite)
 			if suiteErr != nil {
 				return testSuites, suiteErr
@@ -79,14 +84,12 @@ func createTestSuite(suiteFilePath string, chartRoute string, content string, st
 
 	// Append the value files from command to the test suites.
 	suite.Values = append(suite.Values, valueFilesSet...)
-
 	return &suite, nil
 }
 
 // RenderTestSuiteFiles renders a helm suite of test files and returns their TestSuites
 func RenderTestSuiteFiles(helmTestSuiteDir string, chartRoute string, strict bool, valueFilesSet []string, renderValues map[string]interface{}) ([]*TestSuite, error) {
 	testChartPath := filepath.Join(helmTestSuiteDir, "Chart.yaml")
-
 	// Ensure there's a helm file
 	if _, err := os.Stat(testChartPath); err != nil {
 		return nil, err

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -320,9 +320,9 @@ func (s *TestSuite) polishKubernetesProviderSettings(test *TestJob) {
 
 // override chart settings in testjobs when defined in testsuite
 func (s *TestSuite) polishChartSettings(test *TestJob) {
-	if s.Chart.Version != "" {
-		test.Chart.Version = s.Chart.Version
-	}
+	// if s.Chart.Version != "" {
+	// 	test.Chart.Version = s.Chart.Version
+	// }
 	if s.Chart.AppVersion != "" {
 		test.Chart.AppVersion = s.Chart.AppVersion
 	}

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -320,10 +320,10 @@ func (s *TestSuite) polishKubernetesProviderSettings(test *TestJob) {
 
 // override chart settings in testjobs when defined in testsuite
 func (s *TestSuite) polishChartSettings(test *TestJob) {
-	// if s.Chart.Version != "" {
-	// 	test.Chart.Version = s.Chart.Version
-	// }
-	if s.Chart.AppVersion != "" {
+	if test.Chart.Version == "" && s.Chart.Version != "" {
+		test.Chart.Version = s.Chart.Version
+	}
+	if test.Chart.AppVersion == "" && s.Chart.AppVersion != "" {
 		test.Chart.AppVersion = s.Chart.AppVersion
 	}
 }

--- a/test/data/v3/basic/tests/configmap_test.yaml
+++ b/test/data/v3/basic/tests/configmap_test.yaml
@@ -1,6 +1,9 @@
 suite: Configmap multiline Test
 templates:
   - templates/configmap.yaml
+chart:
+  appVersion: 1.0.1
+  version: 0.1.0
 tests:
   - it: should NOT configure ssl params if NOT set to be exposed
     asserts:
@@ -27,3 +30,50 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-basic
+
+  - it: should not override chart values
+    values:
+    - ../values.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app: basic
+            appVersion: 1.0.1
+            chart: basic-0.1.0
+            heritage: Helm
+            release: RELEASE-NAME
+
+  - it: should override chart values
+    values:
+    - ../values.yaml
+    documentIndex: 0
+    chart:
+      appVersion: 2.0.0
+      version: 0.2.0
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app: basic
+            appVersion: 2.0.0
+            chart: basic-0.2.0
+            heritage: Helm
+            release: RELEASE-NAME
+
+  - it: should override chart version only
+    values:
+    - ../values.yaml
+    documentIndex: 0
+    chart:
+      version: 0.3.0
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app: basic
+            appVersion: 1.0.1
+            chart: basic-0.3.0
+            heritage: Helm
+            release: RELEASE-NAME

--- a/test/data/v3/with-helm-tests/charts/child-chart/Chart.yaml
+++ b/test/data/v3/with-helm-tests/charts/child-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: An customized subchart
 name: child-chart
-version: 0.1.0
+version: 0.1.1

--- a/test/data/v3/with-helm-tests/charts/child-chart/tests/service_test.yaml
+++ b/test/data/v3/with-helm-tests/charts/child-chart/tests/service_test.yaml
@@ -1,6 +1,8 @@
 suite: test service
 templates:
   - templates/service.yaml
+chart:
+  version: 0.3.1
 tests:
   - it: should pass
     release:
@@ -21,6 +23,9 @@ tests:
           value:
             app: child-chart
             release: my-release
+      - equal:
+          path: metadata.labels.chart
+          value: child-chart-0.1.1
 
   - it: should render right if values given
     set:
@@ -29,6 +34,8 @@ tests:
         internalPort: 1234
         externalPort: 4321
         name: cool-service
+    chart:
+      version: 0.2.1
     asserts:
       - contains:
           path: spec.ports
@@ -40,3 +47,6 @@ tests:
       - equal:
           path: spec.type
           value: NodePort
+      - equal:
+          path: metadata.labels.chart
+          value: child-chart-0.1.1


### PR DESCRIPTION
The logic most likely should be 

`Job Level values` (if not set) -> `Suite level values` (if not set) -> `Chart level values`

fix for issue https://github.com/helm-unittest/helm-unittest/issues/412

related pull request 1 https://github.com/helm-unittest/helm-unittest/commit/8736620da548522d93156a94cd57f94fa34e8dbd

related pull request 2 https://github.com/helm-unittest/helm-unittest/commit/1693f4f0a35624b1c3f6453d4f0893758e3d99a3