### PR TITLE
issue-457: process chart depencies before metadata override

### DIFF
--- a/pkg/unittest/.snapshots/TestV3RunnerWithTestsInSubchart
+++ b/pkg/unittest/.snapshots/TestV3RunnerWithTestsInSubchart
@@ -3,6 +3,7 @@
 
 
  PASS  test cert-manager rbac	../../test/data/v3/with-subchart/tests/certmanager_test.yaml
+ PASS  test chart renders with dependencies and version overrides	../../test/data/v3/with-subchart/tests/all-charts_test.yaml
  PASS  test child_chart name	../../test/data/v3/with-subchart/charts/child-chart/tests/child_chart_test.yaml
  PASS  test deployment	../../test/data/v3/with-subchart/charts/child-chart/tests/deployment_test.yaml
  PASS  test deployment	../../test/data/v3/with-subchart/tests/deployment_test.yaml
@@ -18,8 +19,8 @@
 
 
 Charts:      1 passed, 1 total
-Test Suites: 13 passed, 13 total
-Tests:       28 passed, 28 total
+Test Suites: 14 passed, 14 total
+Tests:       30 passed, 30 total
 Snapshot:    10 passed, 10 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerWithTestsInSubchartButFlagFalse
+++ b/pkg/unittest/.snapshots/TestV3RunnerWithTestsInSubchartButFlagFalse
@@ -3,6 +3,7 @@
 
 
  PASS  test cert-manager rbac	../../test/data/v3/with-subchart/tests/certmanager_test.yaml
+ PASS  test chart renders with dependencies and version overrides	../../test/data/v3/with-subchart/tests/all-charts_test.yaml
  PASS  test deployment	../../test/data/v3/with-subchart/tests/deployment_test.yaml
  PASS  test ingress	../../test/data/v3/with-subchart/tests/ingress_test.yaml
  PASS  test notes	../../test/data/v3/with-subchart/tests/notes_test.yaml
@@ -12,8 +13,8 @@
 
 
 Charts:      1 passed, 1 total
-Test Suites: 7 passed, 7 total
-Tests:       14 passed, 14 total
+Test Suites: 8 passed, 8 total
+Tests:       16 passed, 16 total
 Snapshot:    5 passed, 5 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -304,8 +304,6 @@ func (t *TestJob) renderV3Chart(targetChart *v3chart.Chart, userValues []byte) (
 		}
 	}
 
-	t.ModifyChartMetadata(targetChart)
-
 	err = v3util.ProcessDependenciesWithMerge(targetChart, values)
 	if err != nil {
 		return nil, false, err
@@ -327,6 +325,8 @@ func (t *TestJob) renderV3Chart(targetChart *v3chart.Chart, userValues []byte) (
 
 	var outputOfFiles map[string]string
 
+	// modify chart metadata before rendering
+	t.ModifyChartMetadata(targetChart)
 	if len(t.KubernetesProvider.Objects) > 0 {
 		outputOfFiles, err = v3engine.RenderWithClientProvider(filteredChart, vals, &t.KubernetesProvider)
 	} else {

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -671,15 +671,6 @@ asserts:
   - matchRegex:
       path: metadata.labels["chart"]
       pattern: "(.*-)?postgresql-1.2.3"
----
-it: should contain subchart and alias subchart without version override
-templates:
-- charts/another-postgresql/templates/deployment.yaml
-- charts/postgresql/templates/deployment.yaml
-asserts:
-  - matchRegex:
-      path: metadata.labels["chart"]
-      pattern: "(.*-)?postgresql-1.3.3"
 `
 	var tj TestJob
 	a := assert.New(t)

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -661,7 +661,7 @@ asserts:
 func TestV3RunSubChartWithVersionOverride(t *testing.T) {
 	c, _ := loader.Load(testV3WithSubChart)
 	manifest := `
-it: should contain subchart and alias subchart when chart version is explicitly st
+it: should contain subchart and alias subchart when chart version is explicitly set
 chart:
   version: 1.2.3
 templates:

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -562,6 +562,28 @@ tests:
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite with subchart", 1, 1, 1, 0, 0)
 }
 
+func TestV3RunSuiteWithSubChartAliasAndVersionOverride(t *testing.T) {
+	suiteDoc := `
+suite: test suite with subchart and version override
+chart:
+  version: 1.2.3
+tests:
+  - it: should render subchart and alias subchart templates
+    templates:
+     - charts/another-postgresql/templates/deployment.yaml
+     - charts/postgresql/templates/deployment.yaml
+    asserts:
+     - matchRegex:
+        path: metadata.labels["chart"]
+        pattern: "(.*-)?postgresql-1.2.3"
+`
+	testSuite := TestSuite{}
+	yaml.Unmarshal([]byte(suiteDoc), &testSuite)
+
+	suiteResult := testSuite.RunV3(testV3WithSubChart, &snapshot.Cache{}, true, "", &results.TestSuiteResult{})
+	assert.True(t, suiteResult.Passed)
+}
+
 func TestV3RunSuiteWithSubChartsTrimmingWhenPass(t *testing.T) {
 	suiteDoc := `
 suite: test cert-manager rbac with trimming

--- a/test/data/v3/with-subchart/tests/all-charts_test.yaml
+++ b/test/data/v3/with-subchart/tests/all-charts_test.yaml
@@ -1,0 +1,40 @@
+suite: test chart renders with dependencies and version overrides
+chart:
+  version: 1.2.3
+tests:
+  - it: should render chart with dependencies and suite level version override
+    asserts:
+      - matchRegex:
+          path: metadata.labels["chart"]
+          pattern: "^.*-1.2.3"
+        template: charts/another-postgresql/templates/deployment.yaml
+      - matchRegex:
+          path: metadata.labels["chart"]
+          pattern: "^.*-1.2.3"
+        template: charts/postgresql/templates/deployment.yaml
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: "^.*-1.2.3"
+        template: charts/cert-manager/templates/deployment.yaml
+
+  - it: should render chart with dependencies and test level version override
+    templates:
+    - deployment.yaml
+    - charts/another-postgresql/templates/deployment.yaml
+    - charts/postgresql/templates/deployment.yaml
+    - charts/cert-manager/templates/deployment.yaml
+    chart:
+      version: 0.0.1
+    set:
+      cert-manager:
+        global:
+          commonLabels:
+            chart: version-0.0.1
+      postgresql:
+        postgresPassword: password
+      another-postgresql:
+        postgresPassword: password
+    asserts:
+      - matchRegex:
+          path: metadata.labels["chart"]
+          pattern: "^.*-0.0.1"


### PR DESCRIPTION
resolves #457 

The issue is with rendering. We should first process dependencies and only then modify values.

- added tests to cover this specific case