### PR TITLE
chore/dependency scan added more attempts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -117,6 +117,10 @@ jobs:
         image-ref: ${{ env.REGISTRY_IMAGE }}:${{ env.HELM_PLUGIN_VERSION }}
         format: sarif
         output: trivy-results.sarif
+        filters: |
+            go:
+              - 'go.mod'
+              - 'go.sum'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -117,10 +117,7 @@ jobs:
         image-ref: ${{ env.REGISTRY_IMAGE }}:${{ env.HELM_PLUGIN_VERSION }}
         format: sarif
         output: trivy-results.sarif
-        filters: |
-            go:
-              - 'go.mod'
-              - 'go.sum'
+        max_attempts: 3
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0


### PR DESCRIPTION
Sometimes trivy fails for reasons not related to vulnerability scanning

Example job https://github.com/helm-unittest/helm-unittest/actions/runs/11621474123/job/32365314492
![Screenshot 2024-11-01 at 08 06 31](https://github.com/user-attachments/assets/547b3dd0-9ec2-4a0c-bcd0-826631216d20)

