### PR TITLE
[WIP/HELP] attempt to fix #471

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.vs
 /.vscode
-
 _scratch
 tpl
 vendor/
@@ -11,6 +10,7 @@ untt-dbg
 untt.exe
 untt-dbg.exe
 _dist
+/.debug
 
 .DS_Store
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
 	github.com/fatih/color v1.17.0
+	github.com/mdaverde/jsonpath v0.2.1
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mdaverde/jsonpath v0.2.1 h1:D/p5PAjMgNAw0BHciKyIiPxz8RbPr0qkeFC8UZc3jF0=
+github.com/mdaverde/jsonpath v0.2.1/go.mod h1:CPqQH8FPN4tjMnyjzuKWZvVyJsTzckI0gYAqAcXEyGo=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
Proposed approach to attempt fixing #471 here is to dump values and patch them.

Slight issue with jsonpath due to the fact it removes nil values instead of setting null. Thats the reason of still using both methods.

it's in the switch around [jsonpath.go#L166](https://github.com/mdaverde/jsonpath/blob/b3fab9520682bc1f7814ced61f896a81d0554381/jsonpath.go#L166)

```
		if value == nil && setNil {
			var nilvalue interface{}
			reflect.ValueOf(child).SetMapIndex(reflect.ValueOf(last), reflect.ValueOf(&nilvalue).Elem())
		} else {
			reflect.ValueOf(child).SetMapIndex(reflect.ValueOf(last), reflect.ValueOf(value))
		}
```

Currently fails:
- TestV3RunnerWithTestsInSubchart
- TestV3RunnerOkGlobalDoubleWithPassedTests