### PR TITLE
Use MkdirAll to ensure path creation in snapshot factory

### DIFF
--- a/pkg/unittest/snapshot/factory.go
+++ b/pkg/unittest/snapshot/factory.go
@@ -31,7 +31,7 @@ func ensureDir(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return os.Mkdir(path, 0755)
+			return os.MkdirAll(path, 0755)
 		}
 		return err
 	}


### PR DESCRIPTION
We're encountering a use-case where execution fails because the path does not exist.

The setup is as follows:
We have a couple of charts which have a somewhat overlapping set of features. Rather than duplicate all the tests for the overlapping features, I wanted to attempt to re-use test suites.

#### Attempt 1 - `-f` flag
Attempt: Use the `-f` flag to point at the test suites

Problem: `values` entries in the testsuite are relative to the testsuite location - Thus any entry in here would point directly at one of the charts, making it useless for the other one.

#### Attempt 2 - `-f` and `-v` flag
Attempt: Use the `-f` flag and the `-v` flag to point at the test suites

Problem: The values files to be used are not named the same thing across the charts, so the command would have to be tweaked individually per chart - I want something standardized.

#### Attempt 3 - Common Templated test suites directly
Attempt: Use [Templated test suites](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#templated-test-suites) to render out a test chart that fits the use-case (e.g. dynamically adjust the `values` entries)

Problem: It is not possible to choose which `values.yaml` file to use for the rendering of the test template.

#### Attempt 4 - Common Templated test suites indirectly
Attempt: Create a test-chart with a Templated test suite in each Helm chart and reference the common Templated test suite as a dependency within this one. Tweak the common templated test suite's settings in the individual chart's test-chart. Run tests by doing `helm dependency build tests-chart && helm unittest --chart-tests-path tests-chart .`

Problem: `helm dependency build tests-chart` will add the common templated test suites chart as a `.tgz` file inside its `charts` directory. When `helm unittest` tries to make a snapshot folder for it, it will fail as it tries to create them at a location matching the path inside the chart - But Helm never unpacks the chart.

As an example, my `tests-chart` references `common-unit-tests` chart version `0.1.0`. When Helm builds the dependencies for it, it will put a `common-unit-tests-0.1.0.tgz` file in the `charts` folder of my `tests-chart`. When running `helm dependency build tests-chart && helm unittest --chart-tests-path tests-chart .`, `helm unittest` will attempt to create the path `charts/common-unit-tests/templates/services/__snapshot__` and fail. 


This Pull Request simply ensures that `helm unittest` can create nested paths in its snapshot factory to support my above use-case. I wasn't sure what kind of test to write for it.


(If I have overlooked anything in my first 3 attempts, please let me know - I would like to go with templated test suites to be able to dynamically alter other parts of the configuration as well)