### PR TITLE
fix(issue-534): fix yaml decoding when comments followed by '----' with test coverage

### DIFF
--- a/pkg/unittest/testdata/chart-yaml-separator/Chart.yaml
+++ b/pkg/unittest/testdata/chart-yaml-separator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yaml-separator
 version: 0.1.0
-description: simple chart to validate yaml separator behavior
+description: chart to validate yaml separator behavior
 keywords:
-  - helm template case1 pkg/unittest/testdata/chart-yaml-separator/tests/__snapshot__ --output-dir _scratch
+  - helm template case1 pkg/unittest/testdata/chart-yaml-separator/ --output-dir _scratch

--- a/pkg/unittest/testdata/chart-yaml-separator/Chart.yaml
+++ b/pkg/unittest/testdata/chart-yaml-separator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: yaml-separator
+version: 0.1.0
+description: simple chart to validate yaml separator behavior
+keywords:
+  - helm template case1 pkg/unittest/testdata/chart-yaml-separator/tests/__snapshot__ --output-dir _scratch

--- a/pkg/unittest/testdata/chart-yaml-separator/templates/deployment.yaml
+++ b/pkg/unittest/testdata/chart-yaml-separator/templates/deployment.yaml
@@ -1,0 +1,22 @@
+# schema https://github.com/yannh/kubernetes-json-schema/blob/master/v1.31.3/deployment.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: example
+  template:
+    metadata:
+      labels:
+        app: example
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+        - name: test-container
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 8080

--- a/pkg/unittest/testdata/chart-yaml-separator/tests/01_test.yaml
+++ b/pkg/unittest/testdata/chart-yaml-separator/tests/01_test.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+---
+suite: should test separator test suite
+templates:
+  - deployment.yaml
+tests:
+  - it: should work with single separator
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment

--- a/pkg/unittest/testdata/chart-yaml-separator/tests/02_test.yaml
+++ b/pkg/unittest/testdata/chart-yaml-separator/tests/02_test.yaml
@@ -9,6 +9,8 @@ tests:
       - isKind:
           of: Deployment
 ---
+# empty block
+---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
 suite: should v2 test separator test suite
 templates:

--- a/pkg/unittest/testdata/chart-yaml-separator/tests/02_test.yaml
+++ b/pkg/unittest/testdata/chart-yaml-separator/tests/02_test.yaml
@@ -1,0 +1,21 @@
+---
+suite: should test separator test suite
+templates:
+  - deployment.yaml
+tests:
+  - it: should work with single separator
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: should v2 test separator test suite
+templates:
+  - deployment.yaml
+tests:
+  - it: should work with single separator
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment

--- a/pkg/unittest/testdata/chart-yaml-separator/tests/03_test.yaml
+++ b/pkg/unittest/testdata/chart-yaml-separator/tests/03_test.yaml
@@ -10,7 +10,7 @@ tests:
       - equal:
           path: spec.replicas
           value: 3
-
+---
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
 suite: should test separator test suite. second suite
@@ -34,3 +34,4 @@ tests:
 ---
 # no suite only comments
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+---

--- a/pkg/unittest/testdata/chart-yaml-separator/tests/03_test.yaml
+++ b/pkg/unittest/testdata/chart-yaml-separator/tests/03_test.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+---
+suite: should test separator test suite. first suite
+templates:
+  - deployment.yaml
+tests:
+  - it: should correctly parse the deployment.yaml file
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json
+suite: should test separator test suite. second suite
+templates:
+  - deployment.yaml
+tests:
+  - it: should correctly parse the deployment.yaml file
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+
+  - it: should correctly parse the deployment.yaml file
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 8080
+---
+# no suite only comments
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json

--- a/pkg/unittest/utils_test.go
+++ b/pkg/unittest/utils_test.go
@@ -136,3 +136,15 @@ func TestV3RunnerWith_Fixture_Chart_FailFast(t *testing.T) {
 		})
 	}
 }
+
+func TestV3RunnerWith_Fixture_Chart_YamlSeparator(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	runner := TestRunner{
+		Printer:   printer.NewPrinter(buffer, nil),
+		TestFiles: []string{"tests/*_test.yaml"},
+		Strict:    false,
+	}
+	_ = runner.RunV3([]string{"testdata/chart-yaml-separator"})
+	assert.Contains(t, buffer.String(), "Test Suites: 5 passed, 5 total")
+	assert.Contains(t, buffer.String(), "Tests:       6 passed, 6 total")
+}


### PR DESCRIPTION
resolves: #543 

The split function works as expected. However, when encountering a comment followed by `---`  current behavior, the logic incorrectly attempts to create a test suite instead of handling the End-of-File (EOF) condition appropriately.

- fix
- added end-2-end tests