### PR TITLE
chore: added open source projects that uses helm unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ tests:
 
 Check [`test/data/v3/basic/`](./test/data/v3/basic) for some basic use cases of a simple chart.
 
+### Community Open Source Examples
+
+> Open-source solutions that uses helm-unittest to improve helm and kubernetes experience
+
+- [Traefik: kubernetes ingress](https://github.com/traefik/traefik-helm-chart/tree/master/traefik/tests)
+- [Prometheus: community charts](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/unittests)
+- [Grafana: kubernetes monitoring](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring)
+- [HiveMQ: mqtt platform](https://github.com/hivemq/helm-charts/tree/develop/charts/hivemq-platform/tests)
+- [Gitlab runner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tree/main/tests?ref_type=heads)
+
 ## Snapshot Testing
 
 Sometimes you may just want to keep the rendered manifest not changed between changes without every details asserted. That's the reason for snapshot testing! Check the tests below:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you are ready for writing tests, check the [DOCUMENT](./DOCUMENT.md) for the 
   - [Yaml JsonPath Support](#yaml-jsonpath-support)
   - [DocumentSelector](#documentselector)
 - [Example](#example)
+  - [Open Source Community Examples](#open-source-community-examples)
 - [Snapshot Testing](#snapshot-testing)
 - [Dependent subchart Testing](#dependent-subchart-testing)
 - [Tests within subchart](#tests-within-subchart)
@@ -224,7 +225,7 @@ tests:
 
 Check [`test/data/v3/basic/`](./test/data/v3/basic) for some basic use cases of a simple chart.
 
-### Community Open Source Examples
+### Open Source Community Examples
 
 > Open-source solutions that uses helm-unittest to improve helm and kubernetes experience
 


### PR DESCRIPTION
`README.md#example`the examples section links to stock examples, which appear somewhat synthetic.  I suggest adding links to open-source projects  with real-life examples to demonstrate/provide more practical context.