### PR TITLE
ISSUE-588: subcharts failed (regression)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Check [`test/data/v3/basic/`](./test/data/v3/basic) for some basic use cases of 
 - [Grafana: kubernetes monitoring](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring)
 - [HiveMQ: mqtt platform](https://github.com/hivemq/helm-charts/tree/develop/charts/hivemq-platform/tests)
 - [Gitlab runner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tree/main/tests?ref_type=heads)
+- [External DNS: kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns/tests)
 
 ## Snapshot Testing
 

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -382,12 +382,13 @@ func (s *TestSuite) runV3TestJobs(
 	jobResults := make([]*results.TestJobResult, len(s.Tests))
 	skipped := 0
 
-	// (Re)load the chart used by this suite (with logging temporarily disabled)
-	log.SetOutput(io.Discard)
-	chart, _ := v3loader.Load(chartPath)
-	log.SetOutput(os.Stdout)
-
 	for idx, testJob := range s.Tests {
+
+		// (Re)load the chart used by this suite (with logging temporarily disabled)
+		log.SetOutput(io.Discard)
+		chart, _ := v3loader.Load(chartPath)
+		log.SetOutput(os.Stdout)
+
 		var jobResult *results.TestJobResult
 		job := results.TestJobResult{DisplayName: testJob.Name, Index: idx}
 

--- a/pkg/unittest/testdata/chart-subchart-v1/Chart.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.1.0
 appVersion: "1.16.0"
 keywords:
-  - helm template test pkg/unittest/testdata/chart-subchart --output-dir _scratch
+  - helm template test pkg/unittest/testdata/chart-subchart-v1 --output-dir _scratch
 
 dependencies:
 - name: subchart

--- a/pkg/unittest/testdata/chart-subchart-v1/Chart.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: with-subchart
+description: simple chart to cover subchart case
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+keywords:
+  - helm template test pkg/unittest/testdata/chart-subchart --output-dir _scratch
+
+dependencies:
+- name: subchart
+  version: 0.1.0
+  condition: subchart.enabled

--- a/pkg/unittest/testdata/chart-subchart-v1/charts/subchart/Chart.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/charts/subchart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: subchart
+description: subchart for testing with library like behaviour
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/pkg/unittest/testdata/chart-subchart-v1/charts/subchart/templates/_helpers.tpl
+++ b/pkg/unittest/testdata/chart-subchart-v1/charts/subchart/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "subchart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/pkg/unittest/testdata/chart-subchart-v1/templates/configmap.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.configmap.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: test
+data:
+  one: two
+{{- if .Values.subchart.enabled }}
+  subchart: "{{ include "subchart.name" . }}"
+{{- end }}
+{{- end -}}

--- a/pkg/unittest/testdata/chart-subchart-v1/tests/configmap-works_test.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/tests/configmap-works_test.yaml
@@ -1,0 +1,20 @@
+suite: without disabled subchart
+templates:
+- configmap.yaml
+release:
+  name: test
+  revision: 1
+chart:
+  version: 1.0.0
+  appVersion: 4.0.0
+
+tests:
+- it: works correctly
+  set:
+    configmap:
+      enabled: true
+    subchart:
+      enabled: true
+  asserts:
+  - exists:
+      path: data.subchart

--- a/pkg/unittest/testdata/chart-subchart-v1/tests/configmap-works_test.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/tests/configmap-works_test.yaml
@@ -9,7 +9,7 @@ chart:
   appVersion: 4.0.0
 
 tests:
-- it: works correctly
+- it: works with enabled subchart
   set:
     configmap:
       enabled: true

--- a/pkg/unittest/testdata/chart-subchart-v1/tests/configmap_test.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/tests/configmap_test.yaml
@@ -9,7 +9,7 @@ chart:
   appVersion: 4.0.0
 
 tests:
-- it: requires a first test to fail
+- it: requires a first test to be fail
   set:
     configmap:
       enabled: true
@@ -17,7 +17,7 @@ tests:
   - hasDocuments:
       count: 1
 
-- it: fails if there is a preceding test with subchart.enabled=false
+- it: should not fail if there is a preceding test with subchart.enabled=false
   set:
     configmap:
       enabled: true

--- a/pkg/unittest/testdata/chart-subchart-v1/tests/configmap_test.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/tests/configmap_test.yaml
@@ -1,0 +1,28 @@
+suite: reproducer
+templates:
+- configmap.yaml
+release:
+  name: test
+  revision: 1
+chart:
+  version: 1.0.0
+  appVersion: 4.0.0
+
+tests:
+- it: requires a first test to fail
+  set:
+    configmap:
+      enabled: true
+  asserts:
+  - hasDocuments:
+      count: 1
+
+- it: fails if there is a preceding test with subchart.enabled=false
+  set:
+    configmap:
+      enabled: true
+    subchart:
+      enabled: true
+  asserts:
+  - exists:
+      path: data.subchart

--- a/pkg/unittest/testdata/chart-subchart-v1/values.yaml
+++ b/pkg/unittest/testdata/chart-subchart-v1/values.yaml
@@ -1,0 +1,2 @@
+subchart:
+  enabled: false

--- a/pkg/unittest/utils_test.go
+++ b/pkg/unittest/utils_test.go
@@ -233,6 +233,18 @@ func TestV3RunnerWith_Fixture_Chart_PostRenderer(t *testing.T) {
 	assert.Contains(t, buffer.String(), "Tests:       4 passed, 4 total")
 }
 
+func TestV3RunnerWith_Fixture_Chart_WithSubchartV1(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	runner := TestRunner{
+		Printer:   printer.NewPrinter(buffer, nil),
+		TestFiles: []string{"tests/*_test.yaml"},
+		Strict:    true,
+	}
+	_ = runner.RunV3([]string{"testdata/chart-subchart-v1"})
+	assert.Contains(t, buffer.String(), "Test Suites: 2 passed, 2 total")
+	assert.Contains(t, buffer.String(), "Tests:       3 passed, 3 total")
+}
+
 func TestSplitBefore(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/schema/helm-testsuite.json
+++ b/schema/helm-testsuite.json
@@ -127,6 +127,8 @@
                 "isKind": true,
                 "isNullOrEmpty": true,
                 "isNotNullOrEmpty": true,
+                "isEmpty": true,
+                "isNotEmpty": true,
                 "isSubset": true,
                 "isNotSubset": true,
                 "isType": true,
@@ -792,6 +794,48 @@
                   },
                   "required": [
                     "isNotType"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT empty.",
+                      "markdownDescription": "**isNotEmpty** (object)\n\nAssert the value of specified path is NOT empty.",
+                      "required": [
+                        "path"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is empty.",
+                      "markdownDescription": "**isEmpty** (object)\n\nAssert the value of specified path is empty.",
+                      "required": [
+                        "path"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isEmpty"
                   ]
                 },
                 {

--- a/test/data/v3/basic/templates/configmap.yaml
+++ b/test/data/v3/basic/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
   my.array:
     - value1
     - value2
+  empty.value:
   special.array:
     - phony-service.phony:graphql
   my.camelcase: {{ .Values.configTests.camelcaseValue | camelcase }}

--- a/test/data/v3/basic/tests/configmap_test.yaml
+++ b/test/data/v3/basic/tests/configmap_test.yaml
@@ -31,6 +31,8 @@ tests:
       - containsDocument:
           kind: ConfigMap
           apiVersion: v1
+      - isNotEmpty:
+          path: metadata.labels
       - equal:
           path: metadata.name
           value: RELEASE-NAME-basic
@@ -48,6 +50,8 @@ tests:
             chart: basic-0.1.0
             heritage: Helm
             release: RELEASE-NAME
+      - isEmpty:
+          path: data["empty.value"]
 
   - it: should override chart values
     values:


### PR DESCRIPTION
Fixes: #588

I think this was moved back in pull request, seems like rebase or similar issue, as I remember this was highlighted in one of the reviews. PR which introduced regression https://github.com/helm-unittest/helm-unittest/pull/521

What is included:
- fix itself
- added end-2-end tests
- added open source community example (external-dns)
- added missing assertions to json schema isEmpty and isNotEmpty