### PR TITLE
feat(documentSelector.skipEmtpyTemplate): skip assertions when templates not found

### DIFF
--- a/internal/common/debug.go
+++ b/internal/common/debug.go
@@ -1,3 +1,4 @@
 package common
 
 const LOG_TEST_SUITE = "test-suite"
+const LOG_TEST_ASSERTION = "test-assertion"

--- a/pkg/unittest/.snapshots/TestV3RunJobOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobOk
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
@@ -19,6 +21,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=10) "matchRegex",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithAssertionFail
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithAssertionFail
@@ -24,6 +24,8 @@
         (string) (len=12) "\t+Deployment"
       },
       Passed: (bool) false,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
@@ -41,6 +43,8 @@
         (string) (len=19) "\tRELEASE-NAME-basic"
       },
       Passed: (bool) false,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=10) "matchRegex",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithAssertionFailFast
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithAssertionFailFast
@@ -24,6 +24,8 @@
         (string) (len=12) "\t+Deployment"
       },
       Passed: (bool) false,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithCapabilitySettings
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithCapabilitySettings
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=12) "hasDocuments",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithChartSettings
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithChartSettings
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
@@ -19,6 +21,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithFailingTemplate
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithFailingTemplate
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=14) "failedTemplate",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithNoCapabilitySettingsEmptyDoc
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithNoCapabilitySettingsEmptyDoc
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=12) "hasDocuments",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithReleaseSettings
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithReleaseSettings
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithRenderPathOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithRenderPathOk
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
@@ -19,6 +21,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=10) "matchRegex",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithSchema
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithSchema
@@ -13,6 +13,8 @@ with-schema:
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=14) "failedTemplate",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithSchemaAndNullValue
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithSchemaAndNullValue
@@ -13,6 +13,8 @@ with-schema:
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=14) "failedTemplate",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithSchemaOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithSchemaOk
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=17) "notFailedTemplate",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTestJobDocumentSelectorOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTestJobDocumentSelectorOk
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
@@ -19,6 +21,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=10) "matchRegex",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTestJobTemplateOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTestJobTemplateOk
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
@@ -19,6 +21,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=10) "matchRegex",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTestJobTemplatesOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTestJobTemplatesOk
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
@@ -19,6 +21,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
@@ -28,6 +32,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=6) "exists",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTestMissingRequiredValueOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTestMissingRequiredValueOk
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=14) "failedTemplate",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTooLongReleaseName
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTooLongReleaseName
@@ -12,6 +12,8 @@
         (string) (len=84) "\ttemplate \"basic/templates/crd_backup.yaml\" not exists or not selected in test suite"
       },
       Passed: (bool) false,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=12) "hasDocuments",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithValueSet
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithValueSet
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunJobWithValuesFile
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithValuesFile
@@ -10,6 +10,8 @@
       FailInfo: ([]string) {
       },
       Passed: (bool) true,
+      Skipped: (bool) false,
+      SkipReason: (string) "",
       AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteNameOverrideFail
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteNameOverrideFail
@@ -18,6 +18,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=14) "failedTemplate",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWhenFail
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWhenFail
@@ -32,6 +32,8 @@
             (string) (len=12) "\t+Deployment"
           },
           Passed: (bool) false,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=5) "equal",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWhenPass
@@ -18,6 +18,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=5) "equal",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -27,6 +29,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=13) "matchSnapshot",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithMultipleTemplatesWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithMultipleTemplatesWhenPass
@@ -18,6 +18,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=10) "matchRegex",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -27,6 +29,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=5) "equal",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -36,6 +40,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=10) "matchRegex",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -45,6 +51,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=5) "equal",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -54,6 +62,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=5) "equal",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -63,6 +73,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=13) "matchSnapshot",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithOverridesWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithOverridesWhenPass
@@ -18,6 +18,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=12) "hasDocuments",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -27,6 +29,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=13) "matchSnapshot",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsTrimmingWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsTrimmingWhenPass
@@ -18,6 +18,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=17) "notFailedTemplate",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsWhenPass
@@ -18,6 +18,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=5) "equal",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -27,6 +29,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=13) "matchSnapshot",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsWithAliasWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsWithAliasWhenPass
@@ -18,6 +18,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=5) "equal",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -27,6 +29,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=13) "matchSnapshot",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -46,6 +50,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=12) "hasDocuments",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithSubfolderWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithSubfolderWhenPass
@@ -18,6 +18,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=5) "equal",
           Not: (bool) false,
           CustomInfo: (string) ""
@@ -27,6 +29,8 @@
           FailInfo: ([]string) {
           },
           Passed: (bool) true,
+          Skipped: (bool) false,
+          SkipReason: (string) "",
           AssertType: (string) (len=13) "matchSnapshot",
           Not: (bool) false,
           CustomInfo: (string) ""

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
@@ -23,7 +23,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 14 passed, 1 skipped, 15 total
-Tests:       42 passed, 2 skipped, 44 total
+Tests:       44 passed, 2 skipped, 46 total
 Snapshot:    4 passed, 4 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithDocumentSelector
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithDocumentSelector
@@ -9,11 +9,12 @@
  PASS  Document Selector to match any template	../../test/data/v3/with-document-select/tests/any_template_test.yaml
  PASS  Document Selector using expression	../../test/data/v3/with-document-select/tests/foo_rbac_test.yaml
  PASS  Document Selector validation with object validation	../../test/data/v3/with-document-select/tests/top_level_test.yaml
+ PASS  skipEmptyTemplates correctly handle 'true' case	../../test/data/v3/with-document-select/tests/external-secrets_test.yaml
 
 
 Charts:      1 passed, 1 total
-Test Suites: 7 passed, 7 total
-Tests:       10 passed, 10 total
+Test Suites: 8 passed, 8 total
+Tests:       13 passed, 13 total
 Snapshot:    1 passed, 1 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
@@ -23,7 +23,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 14 passed, 1 skipped, 15 total
-Tests:       42 passed, 2 skipped, 44 total
+Tests:       44 passed, 2 skipped, 46 total
 Snapshot:    4 passed, 4 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithPassedTests
@@ -23,7 +23,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 14 passed, 1 skipped, 15 total
-Tests:       42 passed, 2 skipped, 44 total
+Tests:       44 passed, 2 skipped, 46 total
 Snapshot:    4 passed, 4 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -65,7 +65,7 @@ func (a *Assertion) Assert(
 		failInfo = append(failInfo, invalidDocumentIndex...)
 	} else {
 
-		if a.config.isEmptyTemplatesSkipped && len(selectedTemplates) == 0 {
+		if a.config.isSkipEmptyTemplate && len(selectedTemplates) == 0 {
 			result.Skipped = true
 			result.SkipReason = "skipped as 'documentSelector.skipEmptyTemplates: true' and 'selectedTemplates: empty'"
 			result.Passed = true

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -65,7 +65,7 @@ func (a *Assertion) Assert(
 		failInfo = append(failInfo, invalidDocumentIndex...)
 	} else {
 
-		if a.config.isSkipEmptyTemplate && len(selectedTemplates) == 0 {
+		if a.configOrDefault().isSkipEmptyTemplate && len(selectedTemplates) == 0 {
 			result.Skipped = true
 			result.SkipReason = "skipped as 'documentSelector.skipEmptyTemplates: true' and 'selectedTemplates: empty'"
 			result.Passed = true

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -284,28 +284,23 @@ func (a *Assertion) constructValidator(assertDef map[string]interface{}) error {
 }
 
 func (a *Assertion) computeTemplatesWithPostRender() map[string][]common.K8sManifest {
-	templates := a.configOrDefault().templatesResult
-
 	// If we PostRendered, there's no guarantee the post-renderer will preserve our file mapping.  If it doesn't, the
 	// parser just puts the whole manifest in one "manifest.yaml" so handle that case:
-	if a.configOrDefault().didPostRender && len(a.configOrDefault().templatesResult) == 1 {
-		var key string
-		for k := range a.configOrDefault().templatesResult {
-			key = k
-		}
-
-		// account for pathname prefix
-		if strings.HasSuffix(key, "manifest.yaml") {
-			a.Template = key
-			templates = make(map[string][]common.K8sManifest)
-			templates[key] = a.configOrDefault().templatesResult[key]
-		} else {
-			templates = a.getDocumentsByDefaultTemplates(a.configOrDefault().templatesResult)
+	var templates map[string][]common.K8sManifest
+	templatesResult := a.configOrDefault().templatesResult
+	if a.configOrDefault().didPostRender && len(templatesResult) == 1 {
+		for key := range templatesResult {
+			if strings.HasSuffix(key, "manifest.yaml") {
+				a.Template = key
+				templates = map[string][]common.K8sManifest{key: templatesResult[key]}
+			} else {
+				templates = a.getDocumentsByDefaultTemplates(templatesResult)
+			}
+			break
 		}
 	} else {
-		templates = a.getDocumentsByDefaultTemplates(a.configOrDefault().templatesResult)
+		templates = a.getDocumentsByDefaultTemplates(templatesResult)
 	}
-
 	return templates
 }
 

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -53,7 +53,7 @@ func (a *Assertion) Assert(
 
 	var templates = a.computeTemplatesWithPostRender()
 
-	// TODO: This could be optimised and computed outside of the Assert function
+	// TODO: This could be optimised and computed once for the test suite
 	selectedDocsByTemplate, indexError := a.selectDocumentsForAssertion(templates)
 	selectedTemplates := a.getKeys(selectedDocsByTemplate)
 

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -12,6 +12,7 @@ import (
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/valueutils"
 
 	"github.com/mitchellh/mapstructure"
+	log "github.com/sirupsen/logrus"
 )
 
 // Assertion defines target and metrics to validate rendered result
@@ -50,30 +51,9 @@ func (a *Assertion) Assert(
 	assertionPassed := false
 	failInfo := make([]string, 0)
 
-	var templates = a.configOrDefault().templatesResult
+	var templates = a.computeTemplatesWithPostRender()
 
-	fmt.Println("In Assert")
-
-	// If we PostRendered, there's no guarantee the post-renderer will preserve our file mapping.  If it doesn't, the
-	// parser just puts the whole manifest in one "manifest.yaml" so handle that case:
-	if a.configOrDefault().didPostRender && len(a.configOrDefault().templatesResult) == 1 {
-		var key string
-		for k := range a.configOrDefault().templatesResult {
-			key = k
-		}
-
-		// account for pathname prefix
-		if strings.HasSuffix(key, "manifest.yaml") {
-			a.Template = key
-			templates = make(map[string][]common.K8sManifest)
-			templates[key] = a.configOrDefault().templatesResult[key]
-		} else {
-			templates = a.getDocumentsByDefaultTemplates(a.configOrDefault().templatesResult)
-		}
-	} else {
-		templates = a.getDocumentsByDefaultTemplates(a.configOrDefault().templatesResult)
-	}
-
+	// TODO: This could be optimised and computed outside of the Assert function
 	selectedDocsByTemplate, indexError := a.selectDocumentsForAssertion(templates)
 	selectedTemplates := a.getKeys(selectedDocsByTemplate)
 
@@ -85,8 +65,11 @@ func (a *Assertion) Assert(
 		failInfo = append(failInfo, invalidDocumentIndex...)
 	} else {
 
-		if isEmptyTemplatesSkipped && len(selectedTemplates) == 0 {
+		if a.config.isEmptyTemplatesSkipped && len(selectedTemplates) == 0 {
 			result.Skipped = true
+			result.SkipReason = "skipped as 'documentSelector.skipEmptyTemplates: true' and 'selectedTemplates: empty'"
+			result.Passed = true
+			log.WithField(common.LOG_TEST_ASSERTION, "assert").Debugln("skip assertion", result.SkipReason)
 			return result
 		}
 
@@ -298,6 +281,32 @@ func (a *Assertion) constructValidator(assertDef map[string]interface{}) error {
 		}
 	}
 	return nil
+}
+
+func (a *Assertion) computeTemplatesWithPostRender() map[string][]common.K8sManifest {
+	templates := a.configOrDefault().templatesResult
+
+	// If we PostRendered, there's no guarantee the post-renderer will preserve our file mapping.  If it doesn't, the
+	// parser just puts the whole manifest in one "manifest.yaml" so handle that case:
+	if a.configOrDefault().didPostRender && len(a.configOrDefault().templatesResult) == 1 {
+		var key string
+		for k := range a.configOrDefault().templatesResult {
+			key = k
+		}
+
+		// account for pathname prefix
+		if strings.HasSuffix(key, "manifest.yaml") {
+			a.Template = key
+			templates = make(map[string][]common.K8sManifest)
+			templates[key] = a.configOrDefault().templatesResult[key]
+		} else {
+			templates = a.getDocumentsByDefaultTemplates(a.configOrDefault().templatesResult)
+		}
+	} else {
+		templates = a.getDocumentsByDefaultTemplates(a.configOrDefault().templatesResult)
+	}
+
+	return templates
 }
 
 type assertTypeDef struct {

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -35,6 +35,7 @@ func (a *Assertion) Assert(
 	renderError error,
 	result *results.AssertionResult,
 	failfast bool,
+	isEmptyTemplatesSkipped bool,
 	didPostRender bool,
 ) *results.AssertionResult {
 	result.AssertType = a.AssertType
@@ -45,6 +46,8 @@ func (a *Assertion) Assert(
 	failInfo := make([]string, 0)
 
 	var templates = templatesResult
+
+	fmt.Println("In Assert")
 
 	// If we PostRendered, there's no guarantee the post-renderer will preserve our file mapping.  If it doesn't, the
 	// parser just puts the whole manifest in one "manifest.yaml" so handle that case:
@@ -76,6 +79,12 @@ func (a *Assertion) Assert(
 		invalidDocumentIndex := []string{"Error:", indexError.Error()}
 		failInfo = append(failInfo, invalidDocumentIndex...)
 	} else {
+
+		if isEmptyTemplatesSkipped && len(selectedTemplates) == 0 {
+			result.Skipped = true
+			return result
+		}
+
 		// Check for failed templates when no documents are found
 		if len(selectedTemplates) == 0 {
 			var validatePassed bool

--- a/pkg/unittest/assertion_test.go
+++ b/pkg/unittest/assertion_test.go
@@ -588,7 +588,6 @@ x:
     path:  a
     value: c
 `
-	// validateSucceededTestAssertions(t, assertionsYAML, 15, renderedMap, true)
 	assertions := make([]Assertion, 2)
 	common.YmlUnmarshalTestHelper(assertionsYAML, &assertions, t)
 

--- a/pkg/unittest/assertion_test.go
+++ b/pkg/unittest/assertion_test.go
@@ -24,7 +24,7 @@ func validateSucceededTestAssertions(
 	a := assert.New(t)
 
 	for idx, assertion := range assertions {
-		result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: idx}, false, didPostRender)
+		result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: idx}, false, false, didPostRender)
 		a.Equal(&results.AssertionResult{
 			Index:      idx,
 			FailInfo:   []string{},
@@ -336,7 +336,7 @@ equal:
 
 	a := assert.New(t)
 
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
+	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false, false)
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "\ttemplate \"not-existed.yaml\" not exists or not selected in test suite"},
@@ -501,7 +501,7 @@ func TestAssertionAssertWhenTemplateNotSpecifiedAndNoDefault(t *testing.T) {
 	common.YmlUnmarshalTestHelper(assertionYAML, &assertion, t)
 
 	a := assert.New(t)
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
+	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false, false)
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "\tassertion.template must be given if testsuite.templates is empty"},
@@ -527,7 +527,7 @@ equal:
 
 	a := assert.New(t)
 
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
+	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false, false)
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "document index 1 is out of rage"},

--- a/pkg/unittest/assertion_test.go
+++ b/pkg/unittest/assertion_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/helm-unittest/helm-unittest/pkg/unittest"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/results"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/valueutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,6 +79,8 @@ func TestAssertionUnmarshalFromYAML(t *testing.T) {
 - notFailedTemplate:
 - containsDocument:
 - lengthEqual:
+- matchSnapshot:
+- matchSnapshotRaw:
 `
 
 	a := assert.New(t)
@@ -560,4 +563,52 @@ equal:
 		Not:        false,
 		CustomInfo: "",
 	}, result)
+}
+
+func TestAssertionWithSkippedDocument(t *testing.T) {
+	manifestDoc := `
+kind: Fake
+apiVersion: v123
+a: b
+e:
+  f: g
+x:
+`
+	manifest := common.TrustedUnmarshalYAML(manifestDoc)
+	renderedMap := map[string][]common.K8sManifest{
+		"t.yaml": {manifest},
+	}
+	assertionsYAML := `
+- template: t.yaml
+  equal:
+    path:  a
+    value: b
+- template: t.yaml
+  notEqual:
+    path:  a
+    value: c
+`
+	// validateSucceededTestAssertions(t, assertionsYAML, 15, renderedMap, true)
+	assertions := make([]Assertion, 2)
+	common.YmlUnmarshalTestHelper(assertionsYAML, &assertions, t)
+
+	ds := &valueutils.DocumentSelector{
+		Path:               "kind",
+		Value:              "NotExist",
+		SkipEmptyTemplates: true,
+	}
+	cfg := AssertionConfigBuilder{
+		TemplatesResult:     renderedMap,
+		SnapshotComparer:    fakeSnapshotComparer(true),
+		RenderSucceed:       true,
+		IsSkipEmptyTemplate: ds.SkipEmptyTemplates,
+	}
+	for _, assertion := range assertions {
+		assertion.DocumentSelector = ds
+		assertion.WithConfig(cfg.Build())
+
+		result := assertion.Assert(&results.AssertionResult{Index: 0})
+		assert.True(t, result.Passed)
+		assert.True(t, result.Skipped)
+	}
 }

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -9,22 +9,22 @@ import (
 )
 
 type TestConfig struct {
-	targetChart             *v3chart.Chart
-	cache                   *snapshot.Cache
-	renderPath              string
-	failFast                bool
-	isEmptyTemplatesSkipped bool
-	postRenderer            PostRendererConfig
+	targetChart         *v3chart.Chart
+	cache               *snapshot.Cache
+	renderPath          string
+	failFast            bool
+	isSkipEmptyTemplate bool
+	postRenderer        PostRendererConfig
 }
 
 func NewTestConfig(chart *v3chart.Chart, cache *snapshot.Cache, options ...func(*TestConfig)) *TestConfig {
 	config := &TestConfig{
-		targetChart:             chart,
-		cache:                   cache,
-		renderPath:              "",
-		failFast:                false,
-		isEmptyTemplatesSkipped: false,
-		postRenderer:            PostRendererConfig{},
+		targetChart:         chart,
+		cache:               cache,
+		renderPath:          "",
+		failFast:            false,
+		isSkipEmptyTemplate: false,
+		postRenderer:        PostRendererConfig{},
 	}
 	for _, option := range options {
 		option(config)
@@ -49,9 +49,9 @@ func WithRenderPath(path string) LoadTestOptionsFunc {
 func WithDocumentSelector(selector *valueutils.DocumentSelector) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
 		if selector != nil {
-			c.isEmptyTemplatesSkipped = selector.SkipEmptyTemplates
+			c.isSkipEmptyTemplate = selector.SkipEmptyTemplates
 		} else {
-			c.isEmptyTemplatesSkipped = false
+			c.isSkipEmptyTemplate = false
 		}
 	}
 }
@@ -64,7 +64,7 @@ func WithPostRendererConfig(config PostRendererConfig) LoadTestOptionsFunc {
 
 func WithSkipEmptyTemplate(config bool) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
-		c.isEmptyTemplatesSkipped = config
+		c.isSkipEmptyTemplate = config
 	}
 }
 

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -8,20 +8,22 @@ import (
 )
 
 type TestConfig struct {
-	targetChart  *v3chart.Chart
-	cache        *snapshot.Cache
-	renderPath   string
-	failFast     bool
-	postRenderer PostRendererConfig
+	targetChart             *v3chart.Chart
+	cache                   *snapshot.Cache
+	renderPath              string
+	failFast                bool
+	isEmptyTemplatesSkipped bool
+	postRenderer            PostRendererConfig
 }
 
 func NewTestConfig(chart *v3chart.Chart, cache *snapshot.Cache, options ...func(*TestConfig)) *TestConfig {
 	config := &TestConfig{
-		targetChart:  chart,
-		cache:        cache,
-		renderPath:   "",
-		failFast:     false,
-		postRenderer: PostRendererConfig{},
+		targetChart:             chart,
+		cache:                   cache,
+		renderPath:              "",
+		failFast:                false,
+		isEmptyTemplatesSkipped: false,
+		postRenderer:            PostRendererConfig{},
 	}
 	for _, option := range options {
 		option(config)
@@ -49,13 +51,20 @@ func WithPostRendererConfig(config PostRendererConfig) LoadTestOptionsFunc {
 	}
 }
 
+func WithEmtpyTemplatesSkipped(config bool) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		c.isEmptyTemplatesSkipped = config
+	}
+}
+
 type AssertionConfig struct {
-	templatesResult  map[string][]common.K8sManifest
-	snapshotComparer validators.SnapshotComparer
-	renderSucceed    bool
-	failFast         bool
-	didPostRender    bool
-	renderError      error
+	templatesResult         map[string][]common.K8sManifest
+	snapshotComparer        validators.SnapshotComparer
+	renderSucceed           bool
+	failFast                bool
+	didPostRender           bool
+	renderError             error
+	isEmptyTemplatesSkipped bool
 }
 
 // AssertionConfigBuilder Required to simplify tests

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -4,6 +4,7 @@ import (
 	"github.com/helm-unittest/helm-unittest/internal/common"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/validators"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/valueutils"
 	v3chart "helm.sh/helm/v3/pkg/chart"
 )
 
@@ -45,45 +46,57 @@ func WithRenderPath(path string) LoadTestOptionsFunc {
 	}
 }
 
+func WithDocumentSelector(selector *valueutils.DocumentSelector) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		if selector != nil {
+			c.isEmptyTemplatesSkipped = selector.SkipEmptyTemplates
+		} else {
+			c.isEmptyTemplatesSkipped = false
+		}
+	}
+}
+
 func WithPostRendererConfig(config PostRendererConfig) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
 		c.postRenderer = config
 	}
 }
 
-func WithEmtpyTemplatesSkipped(config bool) LoadTestOptionsFunc {
+func WithSkipEmptyTemplate(config bool) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
 		c.isEmptyTemplatesSkipped = config
 	}
 }
 
 type AssertionConfig struct {
-	templatesResult         map[string][]common.K8sManifest
-	snapshotComparer        validators.SnapshotComparer
-	renderSucceed           bool
-	failFast                bool
-	didPostRender           bool
-	renderError             error
-	isEmptyTemplatesSkipped bool
+	templatesResult     map[string][]common.K8sManifest
+	snapshotComparer    validators.SnapshotComparer
+	renderSucceed       bool
+	failFast            bool
+	isSkipEmptyTemplate bool
+	didPostRender       bool
+	renderError         error
 }
 
 // AssertionConfigBuilder Required to simplify tests
 type AssertionConfigBuilder struct {
-	TemplatesResult  map[string][]common.K8sManifest
-	SnapshotComparer validators.SnapshotComparer
-	RenderSucceed    bool
-	FailFast         bool
-	DidPostRender    bool
-	RenderError      error
+	TemplatesResult     map[string][]common.K8sManifest
+	SnapshotComparer    validators.SnapshotComparer
+	RenderSucceed       bool
+	FailFast            bool
+	DidPostRender       bool
+	RenderError         error
+	IsSkipEmptyTemplate bool
 }
 
 func (b AssertionConfigBuilder) Build() AssertionConfig {
 	return AssertionConfig{
-		templatesResult:  b.TemplatesResult,
-		snapshotComparer: b.SnapshotComparer,
-		renderSucceed:    b.RenderSucceed,
-		failFast:         b.FailFast,
-		didPostRender:    b.DidPostRender,
-		renderError:      b.RenderError,
+		templatesResult:     b.TemplatesResult,
+		snapshotComparer:    b.SnapshotComparer,
+		renderSucceed:       b.RenderSucceed,
+		failFast:            b.FailFast,
+		didPostRender:       b.DidPostRender,
+		renderError:         b.RenderError,
+		isSkipEmptyTemplate: b.IsSkipEmptyTemplate,
 	}
 }

--- a/pkg/unittest/models_test.go
+++ b/pkg/unittest/models_test.go
@@ -53,9 +53,9 @@ func TestWithDocumentSelector(t *testing.T) {
 	config := NewTestConfig(chart, nil, WithDocumentSelector(&valueutils.DocumentSelector{
 		SkipEmptyTemplates: true,
 	}))
-	assert.True(t, config.isEmptyTemplatesSkipped)
+	assert.True(t, config.isSkipEmptyTemplate)
 	config = NewTestConfig(chart, nil, WithDocumentSelector(nil))
-	assert.False(t, config.isEmptyTemplatesSkipped)
+	assert.False(t, config.isSkipEmptyTemplate)
 }
 
 func TestAssertionConfigBuilder(t *testing.T) {

--- a/pkg/unittest/models_test.go
+++ b/pkg/unittest/models_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/helm-unittest/helm-unittest/internal/common"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/valueutils"
 	"github.com/stretchr/testify/assert"
 	v3chart "helm.sh/helm/v3/pkg/chart"
 )
@@ -45,6 +46,16 @@ func TestWithPostRendererConfig(t *testing.T) {
 	config := NewTestConfig(chart, cache, WithPostRendererConfig(postRendererConfig))
 
 	assert.Equal(t, postRendererConfig, config.postRenderer)
+}
+
+func TestWithDocumentSelector(t *testing.T) {
+	chart := &v3chart.Chart{}
+	config := NewTestConfig(chart, nil, WithDocumentSelector(&valueutils.DocumentSelector{
+		SkipEmptyTemplates: true,
+	}))
+	assert.True(t, config.isEmptyTemplatesSkipped)
+	config = NewTestConfig(chart, nil, WithDocumentSelector(nil))
+	assert.False(t, config.isEmptyTemplatesSkipped)
 }
 
 func TestAssertionConfigBuilder(t *testing.T) {

--- a/pkg/unittest/results/assertion_result.go
+++ b/pkg/unittest/results/assertion_result.go
@@ -12,6 +12,7 @@ type AssertionResult struct {
 	FailInfo   []string
 	Passed     bool
 	Skipped    bool
+	SkipReason string
 	AssertType string
 	Not        bool
 	CustomInfo string

--- a/pkg/unittest/results/assertion_result.go
+++ b/pkg/unittest/results/assertion_result.go
@@ -11,6 +11,7 @@ type AssertionResult struct {
 	Index      int
 	FailInfo   []string
 	Passed     bool
+	Skipped    bool
 	AssertType string
 	Not        bool
 	CustomInfo string

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -438,8 +438,6 @@ func SplitManifests(renderedManifests *bytes.Buffer) map[string]string {
 	var foundMatch = false
 	for _, block := range fileBlocks {
 
-		fmt.Println("TEST JOB BLOCK: ", block)
-
 		if block == "" {
 			continue
 		}

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -235,7 +235,6 @@ func (t *TestJob) configOrDefault() TestConfig {
 	return t.config
 }
 
-
 // RunV3 render the chart and validate it with assertions in TestJob.
 func (t *TestJob) RunV3(
 	result *results.TestJobResult,
@@ -290,7 +289,7 @@ func (t *TestJob) RunV3(
 		failFast:            t.configOrDefault().failFast,
 		didPostRender:       didPostRender,
 		renderError:         renderError,
-		isSkipEmptyTemplate: t.configOrDefault().isEmptyTemplatesSkipped,
+		isSkipEmptyTemplate: t.configOrDefault().isSkipEmptyTemplate,
 	}
 
 	result.Passed, result.AssertsResult = t.runAssertions(assertionsConfig)
@@ -443,7 +442,7 @@ func SplitManifests(renderedManifests *bytes.Buffer) map[string]string {
 
 		match := re.FindStringSubmatch(block)
 
-		if match == nil || len(match) < 2 {
+		if len(match) < 2 {
 			continue
 		}
 

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -302,7 +302,6 @@ func (t *TestJob) RunV3(
 
 	snapshotComparer := &orderedSnapshotComparer{cache: t.configOrDefault().cache, test: t.Name}
 
-	fmt.Println("PREPARE ASSERTIONS config")
 	assertionsConfig := AssertionConfig{
 		templatesResult:         manifestsOfFiles,
 		snapshotComparer:        snapshotComparer,

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -1245,39 +1245,37 @@ func (m *mockPostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, 
 	return args.Get(0).(*bytes.Buffer), args.Error(1)
 }
 
-func TestV3RunJobWithSuccessWhenNoDocumentSelectorSkipEmptyTemplateAndNoTemplates(t *testing.T) {
-	c, _ := loader.Load(testV3BasicChart)
-	manifest := `
-it: should work
-set:
-  image.tag: ""
-chart:
-  version: 9.9.9+test
-  appVersion: 9999
-documentSelector:
-  path: kind
-  value: SomeKind
-  skipEmptyTemplate: true
-asserts:
-  - equal:
-      path: metadata.labels.chart
-      value: basic-9.9.9_test
-    template: templates/deployment.yaml
-  - equal:
-      path: spec.template.spec.containers[0].image
-      value: nginx:9999
-    template: templates/deployment.yaml
-`
-	var tj TestJob
-	unmarshalJobTestHelper(manifest, &tj, t)
-
-	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
-		WithFailFast(true),
-	))
-	testResult := tj.RunV3(&results.TestJobResult{})
-
-	a := assert.New(t)
-	a.Nil(testResult.ExecError)
-	a.True(testResult.Passed)
-	a.Equal(2, len(testResult.AssertsResult))
-}
+// func TestV3RunJobWithSuccessWhenNoDocumentSelectorSkipEmptyTemplateAndNoTemplatesUnderTest(t *testing.T) {
+// 	c, _ := loader.Load(testV3BasicChart)
+// 	manifest := `
+// it: should work
+// set:
+//   image.tag: ""
+// chart:
+//   version: 9.9.9+test
+//   appVersion: 9999
+// template: templates/deployment.yaml
+// documentSelector:
+//   path: kind
+//   value: SomeKind
+//   skipEmptyTemplate: true
+// asserts:
+//   - equal:
+//       path: metadata.labels.chart
+//       value: basic-9.9.9_test
+//   - equal:
+//       path: spec.template.spec.containers[0].image
+//       value: nginx:9999
+// `
+// 	var tj TestJob
+// 	unmarshalJobTestHelper(manifest, &tj, t)
+//
+// 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{}, WithEmtpyTemplatesSkipped(true)))
+// 	testResult := tj.RunV3(&results.TestJobResult{})
+//
+// 	a := assert.New(t)
+// 	a.Nil(testResult.ExecError)
+// 	a.True(testResult.Passed)
+// 	fmt.Println(testResult.Passed)
+// 	a.Equal(2, len(testResult.AssertsResult))
+// }

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -1234,8 +1234,6 @@ func Test_MergeAndPostRender(t *testing.T) {
 
 type mockPostRenderer struct {
 	mock.Mock
-	output string
-	err    error
 }
 
 func (m *mockPostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -1244,3 +1244,40 @@ func (m *mockPostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, 
 	}
 	return args.Get(0).(*bytes.Buffer), args.Error(1)
 }
+
+func TestV3RunJobWithSuccessWhenNoDocumentSelectorSkipEmptyTemplateAndNoTemplates(t *testing.T) {
+	c, _ := loader.Load(testV3BasicChart)
+	manifest := `
+it: should work
+set:
+  image.tag: ""
+chart:
+  version: 9.9.9+test
+  appVersion: 9999
+documentSelector:
+  path: kind
+  value: SomeKind
+  skipEmptyTemplate: true
+asserts:
+  - equal:
+      path: metadata.labels.chart
+      value: basic-9.9.9_test
+    template: templates/deployment.yaml
+  - equal:
+      path: spec.template.spec.containers[0].image
+      value: nginx:9999
+    template: templates/deployment.yaml
+`
+	var tj TestJob
+	unmarshalJobTestHelper(manifest, &tj, t)
+
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
+
+	a := assert.New(t)
+	a.Nil(testResult.ExecError)
+	a.True(testResult.Passed)
+	a.Equal(2, len(testResult.AssertsResult))
+}

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/valueutils"
 	"github.com/stretchr/testify/mock"
 
 	"testing"
@@ -1245,37 +1246,35 @@ func (m *mockPostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, 
 	return args.Get(0).(*bytes.Buffer), args.Error(1)
 }
 
-// func TestV3RunJobWithSuccessWhenNoDocumentSelectorSkipEmptyTemplateAndNoTemplatesUnderTest(t *testing.T) {
-// 	c, _ := loader.Load(testV3BasicChart)
-// 	manifest := `
-// it: should work
-// set:
-//   image.tag: ""
-// chart:
-//   version: 9.9.9+test
-//   appVersion: 9999
-// template: templates/deployment.yaml
-// documentSelector:
-//   path: kind
-//   value: SomeKind
-//   skipEmptyTemplate: true
-// asserts:
-//   - equal:
-//       path: metadata.labels.chart
-//       value: basic-9.9.9_test
-//   - equal:
-//       path: spec.template.spec.containers[0].image
-//       value: nginx:9999
-// `
-// 	var tj TestJob
-// 	unmarshalJobTestHelper(manifest, &tj, t)
-//
-// 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{}, WithEmtpyTemplatesSkipped(true)))
-// 	testResult := tj.RunV3(&results.TestJobResult{})
-//
-// 	a := assert.New(t)
-// 	a.Nil(testResult.ExecError)
-// 	a.True(testResult.Passed)
-// 	fmt.Println(testResult.Passed)
-// 	a.Equal(2, len(testResult.AssertsResult))
-// }
+func TestV3RunJobWithSuccessWhenNoDocumentSelectorSkipEmptyTemplateAndNoTemplatesUnderTest(t *testing.T) {
+	c, _ := loader.Load(testV3BasicChart)
+	manifest := `
+it: should work
+release:
+  name: my-release
+  namespace: test
+documentSelector:
+  path: kind
+  value: SomeKind
+  skipEmptyTemplates: true
+asserts:
+  - equal:
+      path: metadata.name
+      value: my-release-basic
+`
+	var tj TestJob
+	common.YmlUnmarshalTestHelper(manifest, &tj, t)
+
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+		WithSkipEmptyTemplate(true),
+		WithDocumentSelector(&valueutils.DocumentSelector{
+			SkipEmptyTemplates: true,
+		}),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
+
+	assert.Nil(t, testResult.ExecError)
+	assert.True(t, testResult.Passed)
+	assert.Equal(t, 1, len(testResult.AssertsResult))
+}

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -86,16 +86,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	cfg := NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	)
 	tj.WithConfig(*cfg)
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -126,17 +121,12 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	cfg := NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 		WithRenderPath(renderPath),
 	)
 	tj.WithConfig(*cfg)
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 	defer os.RemoveAll(renderPath)
 
 	a := assert.New(t)
@@ -166,16 +156,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	cfg := NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	)
 	tj.WithConfig(*cfg)
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -204,16 +189,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	cfg := NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	)
 	tj.WithConfig(*cfg)
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -245,16 +225,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	cfg := NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	)
 	tj.WithConfig(*cfg)
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -278,17 +253,11 @@ asserts:
 `
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
-
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	cfg := NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	)
 	tj.WithConfig(*cfg)
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -317,13 +286,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", false, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{}))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -352,16 +316,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", false, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
-	// Write Buffer
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -387,15 +345,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -426,16 +379,10 @@ asserts:
 
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(fmt.Sprintf(manifest, file), &tj, t)
-
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -462,15 +409,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -491,17 +433,11 @@ asserts:
 `
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
-
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	cfg := NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	)
 	tj.WithConfig(*cfg)
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -525,16 +461,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	cfg := NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	)
 	tj.WithConfig(*cfg)
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -560,15 +491,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -594,15 +520,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	a.False(testResult.Passed)
@@ -623,16 +544,10 @@ asserts:
 `
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
-<<<<<<< HEAD
-
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	a.False(testResult.Passed)
@@ -654,15 +569,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 	assert.False(t, testResult.Passed)
 	assert.Equal(t, "7", tj.Capabilities.MinorVersion)
 }
@@ -689,15 +599,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -719,16 +624,10 @@ asserts:
 `
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
-
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -750,15 +649,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -783,16 +677,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
-
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
 	a := assert.New(t)
@@ -816,15 +704,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-<<<<<<< HEAD
-	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
-	testResult := tj.RunV3(cfg, &results.TestJobResult{})
-=======
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithFailFast(true),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
->>>>>>> main
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/mock"
 	"os"
 	"path"
+
+	"github.com/stretchr/testify/mock"
 
 	"testing"
 	"time"
@@ -85,7 +86,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -116,7 +118,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, renderPath, &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 	defer os.RemoveAll(renderPath)
 
 	a := assert.New(t)
@@ -146,7 +149,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -175,7 +179,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -207,7 +212,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -232,7 +238,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -261,7 +268,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, false, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", false, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -290,8 +298,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
-	// Write Buffer
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", false, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -317,7 +325,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -349,7 +358,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -376,7 +386,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -398,7 +409,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -422,7 +434,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -448,7 +461,8 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -474,7 +488,8 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	a.False(testResult.Passed)
@@ -496,7 +511,8 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	a.False(testResult.Passed)
@@ -518,7 +534,8 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 	assert.False(t, testResult.Passed)
 	assert.Equal(t, "7", tj.Capabilities.MinorVersion)
 }
@@ -545,7 +562,8 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -568,7 +586,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -590,7 +609,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -615,7 +635,8 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -640,7 +661,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -668,7 +690,8 @@ asserts:
 	a := assert.New(t)
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a.Nil(testResult.ExecError)
 	a.True(testResult.Passed)
@@ -690,7 +713,8 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -811,7 +835,8 @@ asserts:
 	assert := assert.New(t)
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	assert.NoError(testResult.ExecError)
 	assert.True(testResult.Passed, testResult.AssertsResult)
@@ -831,7 +856,8 @@ asserts:
 `
 	var tj TestJob
 	common.YmlUnmarshal(manifest, &tj)
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	a := assert.New(t)
 
@@ -880,7 +906,8 @@ ingress:
 	var tj TestJob
 	unmarshalJobTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -925,7 +952,8 @@ ingress:
 	var tj TestJob
 	unmarshalJobTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+	testResult := tj.RunV3(cfg, &results.TestJobResult{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -961,7 +989,8 @@ func TestV3RunJob_TplFunction_Fail_WithoutAssertion(t *testing.T) {
 	for _, test := range tests {
 		tj := TestJob{}
 		c.Templates = []*v3chart.File{test.template}
-		testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+		cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+		testResult := tj.RunV3(cfg, &results.TestJobResult{})
 		a.Error(testResult.ExecError)
 		a.False(testResult.Passed)
 		a.EqualError(testResult.ExecError, test.error.Error())
@@ -1007,7 +1036,8 @@ asserts:
 
 	for _, test := range tests {
 		c.Templates = []*v3chart.File{test.template}
-		testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+		cfg := NewTestJobConfig(c, &snapshot.Cache{}, "", true, false, PostRendererConfig{})
+		testResult := tj.RunV3(cfg, &results.TestJobResult{})
 		assert.Equal(t, test.expected, testResult.Passed)
 		if test.error != nil {
 			assert.NotNil(t, testResult.ExecError)

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -220,6 +220,7 @@ func (tr *TestRunner) runV3SuitesOfChart(suites []*TestSuite, chartPath string) 
 			chartPassed = false
 			continue
 		}
+		fmt.Println("line 223 suite.RunV3", suite.Name)
 		result := suite.RunV3(chartPath, snapshotCache, tr.Failfast, tr.RenderPath, &results.TestSuiteResult{})
 		chartPassed = chartPassed && result.Passed
 		tr.handleSuiteResult(result)

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -220,7 +220,6 @@ func (tr *TestRunner) runV3SuitesOfChart(suites []*TestSuite, chartPath string) 
 			chartPassed = false
 			continue
 		}
-		fmt.Println("line 223 suite.RunV3", suite.Name)
 		result := suite.RunV3(chartPath, snapshotCache, tr.Failfast, tr.RenderPath, &results.TestSuiteResult{})
 		chartPassed = chartPassed && result.Passed
 		tr.handleSuiteResult(result)

--- a/pkg/unittest/test_runner_test.go
+++ b/pkg/unittest/test_runner_test.go
@@ -356,9 +356,9 @@ func TestV3RunnerOkWithDocumentSelect(t *testing.T) {
 	}
 	passed := runner.RunV3([]string{testV3WithDocumentSelectorChart})
 	assert.True(t, passed, buffer.String())
-	fmt.Println(buffer.String())
-	assert.Contains(t, buffer.String(), "Test Suites: 7 passed, 7 total")
-	assert.Contains(t, buffer.String(), "Tests:       10 passed, 10 total")
+
+	assert.Contains(t, buffer.String(), "Test Suites: 8 passed, 8 total")
+	assert.Contains(t, buffer.String(), "Tests:       13 passed, 13 total")
 }
 
 func TestV3RunnerOkWithTestSkipped(t *testing.T) {

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -388,12 +388,6 @@ func (s *TestSuite) runV3TestJobs(
 		chart, _ := v3loader.Load(chartPath)
 		log.SetOutput(os.Stdout)
 
-		isEmptyTemplatesSkipped := false
-
-		if testJob.DocumentSelector != nil {
-			isEmptyTemplatesSkipped = testJob.DocumentSelector.SkipEmptyTemplates
-		}
-
 		var jobResult *results.TestJobResult
 		job := results.TestJobResult{DisplayName: testJob.Name, Index: idx}
 
@@ -405,13 +399,12 @@ func (s *TestSuite) runV3TestJobs(
 				result.Pass = true
 			}
 		} else {
-			cfg := NewTestConfig(chart, cache,
+			testJob.WithConfig(*NewTestConfig(chart, cache,
 				WithRenderPath(renderPath),
 				WithFailFast(failFast),
 				WithPostRendererConfig(s.PostRendererConfig),
-				WithEmtpyTemplatesSkipped(isEmptyTemplatesSkipped),
-			)
-			testJob.WithConfig(*cfg)
+				WithDocumentSelector(testJob.DocumentSelector),
+			))
 			jobResult = testJob.RunV3(&job)
 			jobResults[idx] = jobResult
 			if idx == 0 {

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -382,10 +382,7 @@ func (s *TestSuite) runV3TestJobs(
 	jobResults := make([]*results.TestJobResult, len(s.Tests))
 	skipped := 0
 
-	fmt.Println("In the job", len(s.Tests))
-
 	for idx, testJob := range s.Tests {
-
 		// (Re)load the chart used by this suite (with logging temporarily disabled)
 		log.SetOutput(io.Discard)
 		chart, _ := v3loader.Load(chartPath)
@@ -412,6 +409,7 @@ func (s *TestSuite) runV3TestJobs(
 				WithRenderPath(renderPath),
 				WithFailFast(failFast),
 				WithPostRendererConfig(s.PostRendererConfig),
+				WithEmtpyTemplatesSkipped(isEmptyTemplatesSkipped),
 			)
 			testJob.WithConfig(*cfg)
 			jobResult = testJob.RunV3(&job)

--- a/pkg/unittest/testdata/chart-skipemptytemplate-no-match/Chart.yaml
+++ b/pkg/unittest/testdata/chart-skipemptytemplate-no-match/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: skipemptytemplate-no-match
+version: 1.0.0
+description: simple chart to cover skipemptytemplate when no matches found
+keywords:
+  - helm template test  pkg/unittest/testdata/chart-skipemptytemplate-no-match --output-dir _scratch

--- a/pkg/unittest/testdata/chart-skipemptytemplate-no-match/templates/external-secrets.yaml
+++ b/pkg/unittest/testdata/chart-skipemptytemplate-no-match/templates/external-secrets.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.externalsecret }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: 'external-credentials'
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        key: 'the/credentials'
+        version: '2'
+  refreshInterval: 0s
+  secretStoreRef:
+    kind: SecretStore
+    name: 'vault-secretstore'
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: 'external-credentials'
+{{- end}}
+

--- a/pkg/unittest/testdata/chart-skipemptytemplate-no-match/templates/pdb.yaml
+++ b/pkg/unittest/testdata/chart-skipemptytemplate-no-match/templates/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: 'greaterorequal-test-pdb'
+spec:
+  minAvailable: 2
+  unhealthyPodEvictionPolicy: AlwaysAllow
+  selector:
+    matchLabels:
+      app: 'greaterorequal-test'

--- a/pkg/unittest/testdata/chart-skipemptytemplate-no-match/tests/external-secrets_test.yaml
+++ b/pkg/unittest/testdata/chart-skipemptytemplate-no-match/tests/external-secrets_test.yaml
@@ -1,0 +1,25 @@
+suite: skipEmptyTemplates correctly handle 'true' case
+templates:
+  - templates/*.y*ml
+tests:
+  - it: should not skip test execution when at least single template rendered
+    set:
+      externalsecret: true
+    documentSelector:
+      path: kind
+      value: ExternalSecret
+      skipEmptyTemplates: true
+    asserts:
+    - equal:
+        path: spec.target.creationPolicy
+        value: Owner
+
+  - it: should skip test execution when no template rendered
+    documentSelector:
+      path: kind
+      value: ExternalSecret
+      skipEmptyTemplates: true
+    asserts:
+    - equal:
+        path: spec.target.creationPolicy
+        value: Owner

--- a/pkg/unittest/utils_test.go
+++ b/pkg/unittest/utils_test.go
@@ -361,7 +361,7 @@ func TestV3RunnerWith_Fixture_Chart_SkipEmptyTemplateWhenEmpty(t *testing.T) {
 		Strict:    true,
 	}
 	_ = runner.RunV3([]string{"testdata/chart-skipemptytemplate-no-match"})
-	fmt.Println(buffer.String())
-	// assert.Contains(t, buffer.String(), "Test Suites: 2 passed, 2 total")
-	// assert.Contains(t, buffer.String(), "Tests:       3 passed, 3 total")
+
+	assert.Contains(t, buffer.String(), "Test Suites: 1 passed, 1 total")
+	assert.Contains(t, buffer.String(), "Tests:       2 passed, 2 total")
 }

--- a/pkg/unittest/utils_test.go
+++ b/pkg/unittest/utils_test.go
@@ -352,3 +352,16 @@ func TestSplitBefore(t *testing.T) {
 		})
 	}
 }
+
+func TestV3RunnerWith_Fixture_Chart_SkipEmptyTemplateWhenEmpty(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	runner := TestRunner{
+		Printer:   printer.NewPrinter(buffer, nil),
+		TestFiles: []string{"tests/*_test.yaml"},
+		Strict:    true,
+	}
+	_ = runner.RunV3([]string{"testdata/chart-skipemptytemplate-no-match"})
+	fmt.Println(buffer.String())
+	// assert.Contains(t, buffer.String(), "Test Suites: 2 passed, 2 total")
+	// assert.Contains(t, buffer.String(), "Tests:       3 passed, 3 total")
+}

--- a/pkg/unittest/valueutils/documentselector.go
+++ b/pkg/unittest/valueutils/documentselector.go
@@ -2,7 +2,6 @@ package valueutils
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 
 	"github.com/helm-unittest/helm-unittest/internal/common"
@@ -61,7 +60,6 @@ func (ds DocumentSelector) SelectDocuments(documentsByTemplate map[string][]comm
 			matchingDocuments[template] = filteredManifests
 		}
 	}
-	fmt.Println("line 63 SelectDocuments:", matchingDocumentsCount)
 	return matchingDocuments, nil
 }
 

--- a/pkg/unittest/valueutils/documentselector.go
+++ b/pkg/unittest/valueutils/documentselector.go
@@ -2,6 +2,7 @@ package valueutils
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/helm-unittest/helm-unittest/internal/common"
@@ -60,6 +61,7 @@ func (ds DocumentSelector) SelectDocuments(documentsByTemplate map[string][]comm
 			matchingDocuments[template] = filteredManifests
 		}
 	}
+	fmt.Println("line 63 SelectDocuments:", matchingDocumentsCount)
 	return matchingDocuments, nil
 }
 

--- a/test/data/v3/basic/tests/ingress_test.yaml
+++ b/test/data/v3/basic/tests/ingress_test.yaml
@@ -112,6 +112,8 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - isKind:
+          of: ThisKindShouldNotBeAsserted
 
   - it: should not skip assertion if enabled
     set:

--- a/test/data/v3/basic/tests/ingress_test.yaml
+++ b/test/data/v3/basic/tests/ingress_test.yaml
@@ -103,3 +103,23 @@ tests:
       - hasDocuments:
           count: 0
       - matchSnapshot: {}
+
+  - it: should skip assertion if not enabled
+    documentSelector:
+      path: kind
+      value: Ingress
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should not skip assertion if enabled
+    set:
+      ingress.enabled: true
+    documentSelector:
+      path: kind
+      value: Ingress
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/test/data/v3/with-document-select/templates/external-secrets.yaml
+++ b/test/data/v3/with-document-select/templates/external-secrets.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.externalsecret }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: 'external-credentials'
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        key: 'the/credentials'
+        version: '2'
+  refreshInterval: 0s
+  secretStoreRef:
+    kind: SecretStore
+    name: 'vault-secretstore'
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: 'external-credentials'
+{{- end}}
+

--- a/test/data/v3/with-document-select/tests/external-secrets_test.yaml
+++ b/test/data/v3/with-document-select/tests/external-secrets_test.yaml
@@ -1,0 +1,25 @@
+suite: skipEmptyTemplates correctly handle 'true' case
+templates:
+  - templates/*.y*ml
+tests:
+  - it: should not skip test execution when at least single template rendered
+    set:
+      externalsecret: true
+    documentSelector:
+      path: kind
+      value: ExternalSecret
+      skipEmptyTemplates: true
+    asserts:
+    - equal:
+        path: spec.target.creationPolicy
+        value: Owner
+
+  - it: should skip test execution when no template rendered
+    documentSelector:
+      path: kind
+      value: ExternalSecret
+      skipEmptyTemplates: true
+    asserts:
+    - equal:
+        path: spec.target.creationPolicy
+        value: Owner

--- a/test/data/v3/with-document-select/tests/skip_empty_templates_test.yaml
+++ b/test/data/v3/with-document-select/tests/skip_empty_templates_test.yaml
@@ -12,3 +12,14 @@ tests:
       - matchRegex:
           path: metadata.name
           pattern: -deployment$
+
+  - it: should skip assertion when skipEmptyTemplates is true and no templates found
+    documentSelector:
+      path: kind
+      value: SomeKind
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ThisKindShouldNotBeAsserted


### PR DESCRIPTION
Fixes #604

- Added capability to assertions when no matching templates are found and skipEmptyTemplate is set to true