### PR TITLE
feat(code cleanup): added configs for job and assertions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,12 @@ test-docker: dockerimage ## Execute 'helm unittests' in container
 	@for f in $(TEST_NAMES); do \
 		echo "running helm unit tests in folder '$(PROJECT_DIR)/test/data/v3/$${f}'"; \
 		docker run \
-		    --platform linux/amd64 \
+			--platform linux/amd64 \
 			-v $(PROJECT_DIR)/test/data/v3/$${f}:/apps:z \
 			--rm  $(DOCKER):$(VERSION) -f tests/*.yaml .;\
 	done
+
+.PHONY: go-lint
+go-lint: ## Execute golang linters
+	gofmt -l -s -w .
+	golangci-lint run --timeout=30m --fix ./...

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -25,17 +25,16 @@ type Assertion struct {
 	requireRenderSuccess bool
 	antonym              bool
 	defaultTemplates     []string
+	config               AssertionConfig
+}
+
+func (a *Assertion) WithConfig(config AssertionConfig) {
+	a.config = config
 }
 
 // Assert validate the rendered manifests with validator
 func (a *Assertion) Assert(
-	templatesResult map[string][]common.K8sManifest,
-	snapshotComparer validators.SnapshotComparer,
-	renderSucceed bool,
-	renderError error,
 	result *results.AssertionResult,
-	failfast bool,
-	didPostRender bool,
 ) *results.AssertionResult {
 	result.AssertType = a.AssertType
 	result.Not = a.Not
@@ -44,13 +43,13 @@ func (a *Assertion) Assert(
 	assertionPassed := false
 	failInfo := make([]string, 0)
 
-	var templates = templatesResult
+	var templates = a.config.templatesResult
 
 	// If we PostRendered, there's no guarantee the post-renderer will preserve our file mapping.  If it doesn't, the
 	// parser just puts the whole manifest in one "manifest.yaml" so handle that case:
-	if didPostRender && len(templatesResult) == 1 {
+	if a.config.didPostRender && len(a.config.templatesResult) == 1 {
 		var key string
-		for k := range templatesResult {
+		for k := range a.config.templatesResult {
 			key = k
 		}
 
@@ -58,12 +57,12 @@ func (a *Assertion) Assert(
 		if strings.HasSuffix(key, "manifest.yaml") {
 			a.Template = key
 			templates = make(map[string][]common.K8sManifest)
-			templates[key] = templatesResult[key]
+			templates[key] = a.config.templatesResult[key]
 		} else {
-			templates = a.getDocumentsByDefaultTemplates(templatesResult)
+			templates = a.getDocumentsByDefaultTemplates(a.config.templatesResult)
 		}
 	} else {
-		templates = a.getDocumentsByDefaultTemplates(templatesResult)
+		templates = a.getDocumentsByDefaultTemplates(a.config.templatesResult)
 	}
 
 	selectedDocsByTemplate, indexError := a.selectDocumentsForAssertion(templates)
@@ -81,12 +80,12 @@ func (a *Assertion) Assert(
 			var validatePassed bool
 			var singleFailInfo []string
 
-			if a.requireRenderSuccess != renderSucceed {
+			if a.requireRenderSuccess != a.config.renderSucceed {
 				invalidRender := "Error: rendered manifest is empty"
 				failInfo = append(failInfo, invalidRender)
 			} else {
 				var emptyTemplate []common.K8sManifest
-				validatePassed, singleFailInfo = a.validateTemplate(emptyTemplate, emptyTemplate, snapshotComparer, renderError, failfast)
+				validatePassed, singleFailInfo = a.validateTemplate(emptyTemplate, emptyTemplate)
 			}
 
 			assertionPassed = validatePassed
@@ -94,7 +93,7 @@ func (a *Assertion) Assert(
 		}
 
 		for idx, template := range selectedTemplates {
-			rendered, ok := templatesResult[template]
+			rendered, ok := a.config.templatesResult[template]
 			var validatePassed bool
 			var singleFailInfo []string
 
@@ -105,7 +104,7 @@ func (a *Assertion) Assert(
 				break
 			}
 
-			if a.requireRenderSuccess != renderSucceed {
+			if a.requireRenderSuccess != a.config.renderSucceed {
 				invalidRender := ""
 				if len(rendered) > 0 {
 					invalidRender = fmt.Sprintf("Error: Invalid rendering: %s", rendered[0][common.RAW])
@@ -120,7 +119,7 @@ func (a *Assertion) Assert(
 			singleTemplateResult[template] = rendered
 
 			selectedDocs := selectedDocsByTemplate[template]
-			validatePassed, singleFailInfo = a.validateTemplate(rendered, selectedDocs, snapshotComparer, renderError, failfast)
+			validatePassed, singleFailInfo = a.validateTemplate(rendered, selectedDocs)
 
 			if !validatePassed {
 				failInfoTemplate := []string{fmt.Sprintf("Template:\t%s", template)}
@@ -142,7 +141,7 @@ func (a *Assertion) Assert(
 	return result
 }
 
-func (a *Assertion) validateTemplate(rendered []common.K8sManifest, selectedDocs []common.K8sManifest, snapshotComparer validators.SnapshotComparer, renderError error, failfast bool) (bool, []string) {
+func (a *Assertion) validateTemplate(rendered []common.K8sManifest, selectedDocs []common.K8sManifest) (bool, []string) {
 	var validatePassed bool
 	var singleFailInfo []string
 
@@ -150,9 +149,9 @@ func (a *Assertion) validateTemplate(rendered []common.K8sManifest, selectedDocs
 		Docs:             rendered,
 		SelectedDocs:     &selectedDocs,
 		Negative:         a.Not != a.antonym,
-		SnapshotComparer: snapshotComparer,
-		RenderError:      renderError,
-		FailFast:         failfast,
+		SnapshotComparer: a.config.snapshotComparer,
+		RenderError:      a.config.renderError,
+		FailFast:         a.config.failFast,
 	})
 
 	return validatePassed, singleFailInfo

--- a/pkg/unittest/assertion_test.go
+++ b/pkg/unittest/assertion_test.go
@@ -24,7 +24,15 @@ func validateSucceededTestAssertions(
 	a := assert.New(t)
 
 	for idx, assertion := range assertions {
-		result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: idx}, false, didPostRender)
+		cfg := AssertionConfigBuilder{
+			TemplatesResult:  renderedMap,
+			SnapshotComparer: fakeSnapshotComparer(true),
+			RenderSucceed:    true,
+			DidPostRender:    didPostRender,
+		}
+		// result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: idx}, false, didPostRender)
+		assertion.WithConfig(cfg.Build())
+		result := assertion.Assert(&results.AssertionResult{Index: idx})
 		a.Equal(&results.AssertionResult{
 			Index:      idx,
 			FailInfo:   []string{},
@@ -336,7 +344,15 @@ equal:
 
 	a := assert.New(t)
 
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
+	cfg := AssertionConfigBuilder{
+		TemplatesResult:  renderedMap,
+		SnapshotComparer: fakeSnapshotComparer(true),
+		RenderSucceed:    true,
+	}
+
+	// cfg := NewAssertionConfig(renderedMap, fakeSnapshotComparer(true), true, false, false, nil)
+	assertion.WithConfig(cfg.Build())
+	result := assertion.Assert(&results.AssertionResult{Index: 0})
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "\ttemplate \"not-existed.yaml\" not exists or not selected in test suite"},
@@ -501,7 +517,14 @@ func TestAssertionAssertWhenTemplateNotSpecifiedAndNoDefault(t *testing.T) {
 	common.YmlUnmarshalTestHelper(assertionYAML, &assertion, t)
 
 	a := assert.New(t)
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
+
+	cfg := AssertionConfigBuilder{
+		TemplatesResult:  renderedMap,
+		SnapshotComparer: fakeSnapshotComparer(true),
+		RenderSucceed:    true,
+	}
+	assertion.WithConfig(cfg.Build())
+	result := assertion.Assert(&results.AssertionResult{Index: 0})
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "\tassertion.template must be given if testsuite.templates is empty"},
@@ -527,7 +550,13 @@ equal:
 
 	a := assert.New(t)
 
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
+	cfg := AssertionConfigBuilder{
+		TemplatesResult:  renderedMap,
+		SnapshotComparer: fakeSnapshotComparer(true),
+		RenderSucceed:    true,
+	}
+	assertion.WithConfig(cfg.Build())
+	result := assertion.Assert(&results.AssertionResult{Index: 0})
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "document index 1 is out of rage"},

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -1,0 +1,80 @@
+package unittest
+
+import (
+	"github.com/helm-unittest/helm-unittest/internal/common"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/validators"
+	v3chart "helm.sh/helm/v3/pkg/chart"
+)
+
+type TestConfig struct {
+	targetChart  *v3chart.Chart
+	cache        *snapshot.Cache
+	renderPath   string
+	failFast     bool
+	postRenderer PostRendererConfig
+}
+
+func NewTestConfig(chart *v3chart.Chart, cache *snapshot.Cache, options ...func(*TestConfig)) *TestConfig {
+	config := &TestConfig{
+		targetChart:  chart,
+		cache:        cache,
+		renderPath:   "",
+		failFast:     false,
+		postRenderer: PostRendererConfig{},
+	}
+	for _, option := range options {
+		option(config)
+	}
+	return config
+}
+
+type LoadTestOptionsFunc func(*TestConfig)
+
+func WithFailFast(failFast bool) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		c.failFast = failFast
+	}
+}
+
+func WithRenderPath(path string) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		c.renderPath = path
+	}
+}
+
+func WithPostRendererConfig(config PostRendererConfig) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		c.postRenderer = config
+	}
+}
+
+type AssertionConfig struct {
+	templatesResult  map[string][]common.K8sManifest
+	snapshotComparer validators.SnapshotComparer
+	renderSucceed    bool
+	failFast         bool
+	didPostRender    bool
+	renderError      error
+}
+
+// AssertionConfigBuilder Required to simplify tests
+type AssertionConfigBuilder struct {
+	TemplatesResult  map[string][]common.K8sManifest
+	SnapshotComparer validators.SnapshotComparer
+	RenderSucceed    bool
+	FailFast         bool
+	DidPostRender    bool
+	RenderError      error
+}
+
+func (b AssertionConfigBuilder) Build() AssertionConfig {
+	return AssertionConfig{
+		templatesResult:  b.TemplatesResult,
+		snapshotComparer: b.SnapshotComparer,
+		renderSucceed:    b.RenderSucceed,
+		failFast:         b.FailFast,
+		didPostRender:    b.DidPostRender,
+		renderError:      b.RenderError,
+	}
+}

--- a/pkg/unittest/models_test.go
+++ b/pkg/unittest/models_test.go
@@ -1,0 +1,69 @@
+package unittest
+
+import (
+	"testing"
+
+	"github.com/helm-unittest/helm-unittest/internal/common"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
+	"github.com/stretchr/testify/assert"
+	v3chart "helm.sh/helm/v3/pkg/chart"
+)
+
+func TestNewTestConfig(t *testing.T) {
+	chart := &v3chart.Chart{}
+	cache := &snapshot.Cache{}
+	config := NewTestConfig(chart, cache)
+
+	assert.NotNil(t, config)
+	assert.Equal(t, chart, config.targetChart)
+	assert.Equal(t, cache, config.cache)
+	assert.Equal(t, "", config.renderPath)
+	assert.False(t, config.failFast)
+	assert.Equal(t, PostRendererConfig{}, config.postRenderer)
+}
+
+func TestWithFailFast(t *testing.T) {
+	chart := &v3chart.Chart{}
+	cache := &snapshot.Cache{}
+	config := NewTestConfig(chart, cache, WithFailFast(true))
+
+	assert.True(t, config.failFast)
+}
+
+func TestWithRenderPath(t *testing.T) {
+	chart := &v3chart.Chart{}
+	cache := &snapshot.Cache{}
+	config := NewTestConfig(chart, cache, WithRenderPath("/path/to/render"))
+
+	assert.Equal(t, "/path/to/render", config.renderPath)
+}
+
+func TestWithPostRendererConfig(t *testing.T) {
+	chart := &v3chart.Chart{}
+	cache := &snapshot.Cache{}
+	postRendererConfig := PostRendererConfig{}
+	config := NewTestConfig(chart, cache, WithPostRendererConfig(postRendererConfig))
+
+	assert.Equal(t, postRendererConfig, config.postRenderer)
+}
+
+func TestAssertionConfigBuilder(t *testing.T) {
+	builder := AssertionConfigBuilder{
+		TemplatesResult:  map[string][]common.K8sManifest{},
+		SnapshotComparer: nil,
+		RenderSucceed:    true,
+		FailFast:         true,
+		DidPostRender:    true,
+		RenderError:      nil,
+	}
+
+	config := builder.Build()
+
+	assert.NotNil(t, config)
+	assert.Equal(t, builder.TemplatesResult, config.templatesResult)
+	assert.Equal(t, builder.SnapshotComparer, config.snapshotComparer)
+	assert.True(t, config.renderSucceed)
+	assert.True(t, config.failFast)
+	assert.True(t, config.didPostRender)
+	assert.Nil(t, config.renderError)
+}

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/mock"
 	"os"
 	"path"
+
+	"github.com/stretchr/testify/mock"
 
 	"testing"
 	"time"
@@ -85,7 +86,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	)
+	tj.WithConfig(*cfg)
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -116,7 +121,12 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, renderPath, &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+		WithRenderPath(renderPath),
+	)
+	tj.WithConfig(*cfg)
+	testResult := tj.RunV3(&results.TestJobResult{})
 	defer os.RemoveAll(renderPath)
 
 	a := assert.New(t)
@@ -146,7 +156,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	)
+	tj.WithConfig(*cfg)
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -175,7 +189,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	)
+	tj.WithConfig(*cfg)
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -207,7 +225,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	)
+	tj.WithConfig(*cfg)
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -232,7 +254,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	)
+	tj.WithConfig(*cfg)
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -261,7 +287,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, false, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{}))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -290,7 +317,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 	// Write Buffer
 
 	a := assert.New(t)
@@ -317,7 +347,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -349,7 +382,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -376,7 +412,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -398,7 +437,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	)
+	tj.WithConfig(*cfg)
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -422,7 +465,11 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	cfg := NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	)
+	tj.WithConfig(*cfg)
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -448,7 +495,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -474,7 +524,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	a.False(testResult.Passed)
@@ -495,8 +548,10 @@ asserts:
 `
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
-
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	a.False(testResult.Passed)
@@ -518,7 +573,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 	assert.False(t, testResult.Passed)
 	assert.Equal(t, "7", tj.Capabilities.MinorVersion)
 }
@@ -545,7 +603,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -568,7 +629,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -590,7 +654,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -615,7 +682,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -640,7 +710,10 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -668,7 +741,10 @@ asserts:
 	a := assert.New(t)
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a.Nil(testResult.ExecError)
 	a.True(testResult.Passed)
@@ -690,7 +766,10 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -811,7 +890,10 @@ asserts:
 	assert := assert.New(t)
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	assert.NoError(testResult.ExecError)
 	assert.True(testResult.Passed, testResult.AssertsResult)
@@ -831,7 +913,11 @@ asserts:
 `
 	var tj TestJob
 	common.YmlUnmarshal(manifest, &tj)
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 
@@ -880,7 +966,10 @@ ingress:
 	var tj TestJob
 	unmarshalJobTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -925,7 +1014,10 @@ ingress:
 	var tj TestJob
 	unmarshalJobTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithFailFast(true),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -961,7 +1053,10 @@ func TestV3RunJob_TplFunction_Fail_WithoutAssertion(t *testing.T) {
 	for _, test := range tests {
 		tj := TestJob{}
 		c.Templates = []*v3chart.File{test.template}
-		testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+		tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+			WithFailFast(true),
+		))
+		testResult := tj.RunV3(&results.TestJobResult{})
 		a.Error(testResult.ExecError)
 		a.False(testResult.Passed)
 		a.EqualError(testResult.ExecError, test.error.Error())
@@ -1007,7 +1102,10 @@ asserts:
 
 	for _, test := range tests {
 		c.Templates = []*v3chart.File{test.template}
-		testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
+		tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+			WithFailFast(true),
+		))
+		testResult := tj.RunV3(&results.TestJobResult{})
 		assert.Equal(t, test.expected, testResult.Passed)
 		if test.error != nil {
 			assert.NotNil(t, testResult.ExecError)

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -249,7 +249,7 @@ func (tr *TestRunner) handleSuiteResult(result *results.TestSuiteResult) {
 	for _, testsResult := range result.TestsResult {
 		if testsResult == nil {
 			if tr.Failfast {
-				log.WithField("test-runner", "handle-suite-result").Debug("--failfast skip test")
+				log.WithField("test-runner", "handle-suite-result").Debug("--failFast skip test")
 			}
 			continue
 		}

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -400,7 +400,13 @@ func (s *TestSuite) runV3TestJobs(
 				result.Pass = true
 			}
 		} else {
-			jobResult = testJob.RunV3(chart, cache, failFast, renderPath, &job, s.PostRendererConfig)
+			cfg := NewTestConfig(chart, cache,
+				WithRenderPath(renderPath),
+				WithFailFast(failFast),
+				WithPostRendererConfig(s.PostRendererConfig),
+			)
+			testJob.WithConfig(*cfg)
+			jobResult = testJob.RunV3(&job)
 			jobResults[idx] = jobResult
 			if idx == 0 {
 				result.Pass = jobResult.Passed


### PR DESCRIPTION
Feels like a good idea, before to adding/fixing an issue, to actually refactore slightly how arguments passed around. From `test suite -> test job -> assertion`. The list is growing, and is hard to keep track on which flag is in which order should be. 

This pull request is just refactoring. Actual fix is going to be an another PR https://github.com/helm-unittest/helm-unittest/pull/609