### PR TITLE
fix(issue-634): memory leak

### DIFF
--- a/pkg/unittest/benchmark_test.go
+++ b/pkg/unittest/benchmark_test.go
@@ -1,0 +1,58 @@
+package unittest
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/printer"
+	"github.com/stretchr/testify/assert"
+)
+
+// This benchmark test measures the CPU and memory performance of the RunV3 method in the
+// TestRunner type when running against a large number of test files. It programmatically
+// creates 400 copies of a sample test file, runs the test suite using these files,
+// and cleans up the generated files after the benchmark completes.
+// The test uses a silent printer to avoid output overhead during benchmarking.
+func BenchmarkNewTestForCPUAndMemory(b *testing.B) {
+	files, err := copyFile("testdata/chart-benchmark/tests", "main_test.yaml", 400)
+	assert.NoError(b, err)
+
+	b.Cleanup(func() {
+		for _, file := range files {
+			err := os.Remove(file)
+			assert.NoError(b, err)
+		}
+	})
+
+	runner := TestRunner{
+		Printer:   printer.NewPrinter(io.Discard, nil),
+		TestFiles: []string{"tests/*_test.yaml"},
+		Strict:    true,
+	}
+
+	for b.Loop() {
+		_ = runner.RunV3([]string{"testdata/chart-benchmark"})
+	}
+}
+
+func copyFile(dir, src string, times int) ([]string, error) {
+	// Open the source file for reading
+	in, err := os.ReadFile(fmt.Sprintf("%s/%s", dir, src))
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+
+	for i := 0; i < times; i++ {
+		fileName := fmt.Sprintf("%s/%d-%s", dir, i, src)
+		err := os.WriteFile(fileName, in, 0644)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, fileName)
+	}
+
+	return result, nil
+}

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -382,11 +382,14 @@ func (s *TestSuite) runV3TestJobs(
 	jobResults := make([]*results.TestJobResult, len(s.Tests))
 	skipped := 0
 
+	// (Re)load the chart used by this suite (with logging temporarily disabled)
+	log.SetOutput(io.Discard)
+	chart, _ := v3loader.Load(chartPath)
+	log.SetOutput(os.Stdout)
+
 	for idx, testJob := range s.Tests {
-		// (Re)load the chart used by this suite (with logging temporarily disabled)
-		log.SetOutput(io.Discard)
-		chart, _ := v3loader.Load(chartPath)
-		log.SetOutput(os.Stdout)
+
+		copiedChart := chart
 
 		var jobResult *results.TestJobResult
 		job := results.TestJobResult{DisplayName: testJob.Name, Index: idx}
@@ -399,7 +402,7 @@ func (s *TestSuite) runV3TestJobs(
 				result.Pass = true
 			}
 		} else {
-			testJob.WithConfig(*NewTestConfig(chart, cache,
+			testJob.WithConfig(*NewTestConfig(copiedChart, cache,
 				WithRenderPath(renderPath),
 				WithFailFast(failFast),
 				WithPostRendererConfig(s.PostRendererConfig),

--- a/pkg/unittest/testdata/chart-benchmark/Chart.yaml
+++ b/pkg/unittest/testdata/chart-benchmark/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: benchmark
+version: 0.1.0
+description: simple chart to validate bencharking tests
+keywords:
+  - helm template test  pkg/unittest/testdata/chart-benchmark --output-dir _scratch

--- a/pkg/unittest/testdata/chart-benchmark/templates/configmap.yaml
+++ b/pkg/unittest/testdata/chart-benchmark/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: benchmark-configmap
+  labels:
+    app: my-app
+    appVersion: {{ .Chart.AppVersion | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  my.array:
+    - value1
+    - value2

--- a/pkg/unittest/testdata/chart-benchmark/tests/main_test.yaml
+++ b/pkg/unittest/testdata/chart-benchmark/tests/main_test.yaml
@@ -1,0 +1,52 @@
+suite: a fail-fast first test
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: should NOT configure ssl params if NOT set to be exposed
+    asserts:
+      - notMatchRegex:
+          path: data["my.conf"]
+          pattern: cacertfile
+      - contains:
+          path: data["my.array"]
+          content: value1
+          count: 1
+
+  - it: should not fail
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+
+  - it: should run a test
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - equal:
+          path: metadata.name
+          value: benchmark-configmap
+
+  - it: should validate values
+    values:
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: metadata.name
+          value: benchmark-configmap
+
+  - it: should validate metadata labels
+    values:
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app: my-app
+            appVersion: ""
+            chart: benchmark-0.1.0
+            heritage: Helm
+            release: RELEASE-NAME

--- a/pkg/unittest/valueutils/main_test.yaml
+++ b/pkg/unittest/valueutils/main_test.yaml
@@ -1,0 +1,52 @@
+suite: a fail-fast first test
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: should NOT configure ssl params if NOT set to be exposed
+    asserts:
+      - notMatchRegex:
+          path: data["my.conf"]
+          pattern: cacertfile
+      - contains:
+          path: data["my.array"]
+          content: value1
+          count: 1
+
+  - it: should not fail
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+
+  - it: should run a test
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - equal:
+          path: metadata.name
+          value: benchmark-configmap
+
+  - it: should validate values
+    values:
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: metadata.name
+          value: benchmark-configmap
+
+  - it: should validate metadata labels
+    values:
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app: my-app
+            appVersion: ""
+            chart: benchmark-0.1.0
+            heritage: Helm
+            release: RELEASE-NAME


### PR DESCRIPTION
Fixes #634

- added benchmark tests, to make sure in future we have a way to identiy it

Without the fix
![Screenshot 2025-06-24 at 12 46 49](https://github.com/user-attachments/assets/c21acff1-59e5-43d6-97b7-9aa1266315e6)


With the fix (3x times less entities created)
![Screenshot 2025-06-24 at 12 49 16](https://github.com/user-attachments/assets/7d348901-e3b3-436a-babf-cc8e3eb7941d)

There is as well difference in cycles

```
BenchmarkNewTestForCPUAndMemoryNew-16    	       1	19152080068 ns/op

BenchmarkNewTestForCPUAndMemoryNew-16    	       1	4583115567 ns/op
```

The difference is 4x times.

Just need to find out how to correctly copy chart
