### PR TITLE
Fix spelling mistake in range errors

### DIFF
--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -227,7 +227,7 @@ func (a *Assertion) selectDocumentsByIndex(index int, docs map[string][]common.K
 
 	for template, manifests := range docs {
 		if index >= len(manifests) {
-			return map[string][]common.K8sManifest{}, fmt.Errorf("document index %d is out of rage", a.DocumentIndex)
+			return map[string][]common.K8sManifest{}, fmt.Errorf("document index %d is out of range", a.DocumentIndex)
 		}
 
 		selectedDocs[template] = []common.K8sManifest{manifests[index]}

--- a/pkg/unittest/assertion_test.go
+++ b/pkg/unittest/assertion_test.go
@@ -557,7 +557,7 @@ equal:
 	result := assertion.Assert(&results.AssertionResult{Index: 0})
 	a.Equal(&results.AssertionResult{
 		Index:      0,
-		FailInfo:   []string{"Error:", "document index 1 is out of rage"},
+		FailInfo:   []string{"Error:", "document index 1 is out of range"},
 		Passed:     false,
 		AssertType: "equal",
 		Not:        false,


### PR DESCRIPTION
Range errors said 'rage' instead of 'range'