### PR TITLE
Modernize the code for better readabillity.

### DIFF
--- a/cmd/helm-unittest/helm_unittest_test.go
+++ b/cmd/helm-unittest/helm_unittest_test.go
@@ -334,6 +334,6 @@ func TestValidateUnittestChartTestsPathFlag(t *testing.T) {
 }
 
 // Using %T
-func typeofObject(variable interface{}) string {
+func typeofObject(variable any) string {
 	return fmt.Sprintf("%T", variable)
 }

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -1,7 +1,7 @@
 package common
 
 // K8sManifest type for rendered manifest unmarshalled to
-type K8sManifest map[string]interface{}
+type K8sManifest map[string]any
 
 // RAW the key value for making content parsable as K8sManifest
 const RAW string = "raw"

--- a/internal/common/utilities.go
+++ b/internal/common/utilities.go
@@ -33,7 +33,7 @@ func YamlNewEncoder(w io.Writer) *yamlv3.Encoder {
 }
 
 // TrustedMarshalYAML marshal yaml without error returned, if an error happens it panics
-func TrustedMarshalYAML(d interface{}) string {
+func TrustedMarshalYAML(d any) string {
 	byteBuffer := new(bytes.Buffer)
 	yamlEncoder := yamlv3.NewEncoder(byteBuffer)
 	yamlEncoder.SetIndent(YAMLINDENTION)
@@ -45,7 +45,7 @@ func TrustedMarshalYAML(d interface{}) string {
 }
 
 // TrustedUnmarshalYAML unmarshal yaml without error returned, if an error happens it panics
-func TrustedUnmarshalYAML(d string) map[string]interface{} {
+func TrustedUnmarshalYAML(d string) map[string]any {
 	parsedYaml := K8sManifest{}
 	yamlDecoder := yamlv3.NewDecoder(strings.NewReader(d))
 	if err := yamlDecoder.Decode(&parsedYaml); err != nil {
@@ -58,11 +58,11 @@ func YamlToJson(in string) ([]byte, error) {
 	return yaml.YAMLToJSON([]byte(in))
 }
 
-func YmlUnmarshal(in string, out interface{}) error {
+func YmlUnmarshal(in string, out any) error {
 	return yamlv3.Unmarshal([]byte(in), out)
 }
 
-func YmlMarshall(in interface{}) (string, error) {
+func YmlMarshall(in any) (string, error) {
 	out, err := yaml.Marshal(in)
 	if err != nil {
 		return "", err
@@ -76,7 +76,7 @@ func YmlUnmarshalTestHelper(input string, out any, t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func YmlMarshallTestHelper(in interface{}, t *testing.T) string {
+func YmlMarshallTestHelper(in any, t *testing.T) string {
 	t.Helper()
 	out, err := yaml.Marshal(in)
 	assert.NoError(t, err)

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -248,8 +248,8 @@ func (a *Assertion) noFileErrMessage(template string) string {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler, constructing the validator according to the assert type.
-func (a *Assertion) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	assertDef := make(map[string]interface{})
+func (a *Assertion) UnmarshalYAML(unmarshal func(any) error) error {
+	assertDef := make(map[string]any)
 	if err := unmarshal(&assertDef); err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func (a *Assertion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // parseBasicFields parses basic fields like documentIndex, not, and template.
-func (a *Assertion) parseBasicFields(assertDef map[string]interface{}) {
+func (a *Assertion) parseBasicFields(assertDef map[string]any) {
 	if documentIndex, ok := assertDef["documentIndex"].(int); ok {
 		a.DocumentIndex = documentIndex
 	} else {
@@ -288,8 +288,8 @@ func (a *Assertion) parseBasicFields(assertDef map[string]interface{}) {
 }
 
 // parseDocumentSelector parses the documentSelector field if present.
-func (a *Assertion) parseDocumentSelector(assertDef map[string]interface{}) error {
-	if documentSelector, ok := assertDef["documentSelector"].(map[string]interface{}); ok {
+func (a *Assertion) parseDocumentSelector(assertDef map[string]any) error {
+	if documentSelector, ok := assertDef["documentSelector"].(map[string]any); ok {
 		s, err := valueutils.NewDocumentSelector(documentSelector)
 		if err != nil {
 			return err
@@ -300,7 +300,7 @@ func (a *Assertion) parseDocumentSelector(assertDef map[string]interface{}) erro
 }
 
 // validateAssertionType validates the assertion type and ensures at least one is defined.
-func (a *Assertion) validateAssertionType(assertDef map[string]interface{}) error {
+func (a *Assertion) validateAssertionType(assertDef map[string]any) error {
 	for key := range assertDef {
 		if key != "template" && key != "documentIndex" && key != "not" {
 			return fmt.Errorf("Assertion type `%s` is invalid", key)
@@ -309,7 +309,7 @@ func (a *Assertion) validateAssertionType(assertDef map[string]interface{}) erro
 	return fmt.Errorf("no assertion type defined")
 }
 
-func (a *Assertion) constructValidator(assertDef map[string]interface{}) error {
+func (a *Assertion) constructValidator(assertDef map[string]any) error {
 	for assertName, correspondDef := range assertTypeMapping {
 		if params, ok := assertDef[assertName]; ok {
 			if a.validator != nil {

--- a/pkg/unittest/assertion_test.go
+++ b/pkg/unittest/assertion_test.go
@@ -84,7 +84,7 @@ func TestAssertionUnmarshalFromYAML(t *testing.T) {
 `
 
 	a := assert.New(t)
-	assertionsAsMap := make([]map[string]interface{}, 33)
+	assertionsAsMap := make([]map[string]any, 33)
 	common.YmlUnmarshalTestHelper(assertionsYAML, &assertionsAsMap, t)
 
 	assertions := make([]Assertion, 33)
@@ -225,7 +225,7 @@ func TestReverseAssertionTheSameAsOriginalOneWithNotTrue(t *testing.T) {
 
 type fakeSnapshotComparer bool
 
-func (c fakeSnapshotComparer) CompareToSnapshot(content interface{}, optFns ...func(options *snapshot.CacheOptions) error) *snapshot.CompareResult {
+func (c fakeSnapshotComparer) CompareToSnapshot(content any, optFns ...func(options *snapshot.CacheOptions) error) *snapshot.CompareResult {
 	return &snapshot.CompareResult{
 		Passed: bool(c),
 	}

--- a/pkg/unittest/deep_copy.go
+++ b/pkg/unittest/deep_copy.go
@@ -53,16 +53,16 @@ func getTemplateFileNamePattern(fileName string) string {
 	return pattern
 }
 
-func copySet(setValues map[string]interface{}) map[string]interface{} {
+func copySet(setValues map[string]any) map[string]any {
 	copiedSet, err := copystructure.Copy(setValues)
 	if err != nil {
 		panic(err)
 	}
 
-	copiedSetValues := copiedSet.(map[string]interface{})
+	copiedSetValues := copiedSet.(map[string]any)
 	// if we have an empty map, make sure it is initialized
 	if copiedSetValues == nil {
-		copiedSetValues = make(map[string]interface{})
+		copiedSetValues = make(map[string]any)
 	}
 
 	return copiedSetValues

--- a/pkg/unittest/formatter/formatter.go
+++ b/pkg/unittest/formatter/formatter.go
@@ -45,7 +45,7 @@ func formatDurationMilliSeconds(d time.Duration) string {
 	return fmt.Sprintf("%d", d.Milliseconds())
 }
 
-func writeContentToFile(noXMLHeader bool, content interface{}, w io.Writer) error {
+func writeContentToFile(noXMLHeader bool, content any, w io.Writer) error {
 
 	// to xml
 	bytes, err := xml.MarshalIndent(content, "", "\t")

--- a/pkg/unittest/formatter/junit_report_xml_test.go
+++ b/pkg/unittest/formatter/junit_report_xml_test.go
@@ -52,7 +52,7 @@ func assertJUnitTestSuite(assert *assert.Assertions, expected, actual []JUnitTes
 		actualLength := len(actual)
 		assert.Equal(len(expected), actualLength)
 
-		for i := 0; i < actualLength; i++ {
+		for i := range actualLength {
 			assert.Equal(expected[i].Tests, actual[i].Tests)
 			assert.Equal(expected[i].Errors, actual[i].Errors)
 			assert.Equal(expected[i].Failures, actual[i].Failures)
@@ -73,7 +73,7 @@ func assertJUnitTestCase(assert *assert.Assertions, expected, actual []JUnitTest
 		actualLength := len(actual)
 		assert.Equal(len(expected), actualLength)
 
-		for i := 0; i < actualLength; i++ {
+		for i := range actualLength {
 			assert.Equal(expected[i].Classname, actual[i].Classname)
 			assert.Equal(expected[i].Name, actual[i].Name)
 
@@ -105,7 +105,7 @@ func assertJUnitProperty(assert *assert.Assertions, expected, actual []JUnitProp
 		actualLength := len(actual)
 		assert.Equal(len(expected), actualLength)
 
-		for i := 0; i < actualLength; i++ {
+		for i := range actualLength {
 			assert.Equal(expected[i].Name, actual[i].Name)
 			assert.Equal(expected[i].Value, actual[i].Value)
 		}

--- a/pkg/unittest/formatter/nunit_report_xml_test.go
+++ b/pkg/unittest/formatter/nunit_report_xml_test.go
@@ -48,7 +48,7 @@ func validateNUnitTestSuite(assert *assert.Assertions, expected, actual []NUnitT
 		actualLength := len(actual)
 		assert.Equal(len(expected), actualLength)
 
-		for i := 0; i < actualLength; i++ {
+		for i := range actualLength {
 			assert.Equal(expected[i].Name, actual[i].Name)
 			assert.Equal(expected[i].Description, actual[i].Description)
 			assert.Equal(expected[i].Success, actual[i].Success)
@@ -73,7 +73,7 @@ func validatNUnitTestCase(assert *assert.Assertions, expected, actual []NUnitTes
 		actualLength := len(actual)
 		assert.Equal(len(expected), actualLength)
 
-		for i := 0; i < actualLength; i++ {
+		for i := range actualLength {
 			assert.Equal(expected[i].Name, actual[i].Name)
 			assert.Equal(expected[i].Description, actual[i].Description)
 			assert.Equal(expected[i].Success, actual[i].Success)

--- a/pkg/unittest/formatter/sonar_report_xml_test.go
+++ b/pkg/unittest/formatter/sonar_report_xml_test.go
@@ -31,7 +31,7 @@ func createSonarTestCase(name string, duration string, isError bool, isFailed bo
 func validateSonarFiles(assert *assert.Assertions, expected, actual []SonarFile) {
 	assert.Equal(len(expected), len(actual))
 
-	for i := 0; i < len(actual); i++ {
+	for i := range actual {
 		assert.Equal(expected[i].Path, actual[i].Path)
 		validateSonarTestCases(assert, expected[i].TestCases, actual[i].TestCases)
 	}
@@ -40,7 +40,7 @@ func validateSonarFiles(assert *assert.Assertions, expected, actual []SonarFile)
 func validateSonarTestCases(assert *assert.Assertions, expected, actual []SonarTestCase) {
 	assert.Equal(len(expected), len(actual))
 
-	for i := 0; i < len(actual); i++ {
+	for i := range actual {
 		assert.Equal(expected[i].Name, actual[i].Name)
 		assert.Equal(expected[i].Duration, actual[i].Duration)
 

--- a/pkg/unittest/formatter/xunit_report_xml_test.go
+++ b/pkg/unittest/formatter/xunit_report_xml_test.go
@@ -48,7 +48,7 @@ func assertXUnitTestAssemblies(assert *assert.Assertions, expected, actual []XUn
 		actualLength := len(actual)
 		assert.Equal(len(expected), actualLength)
 
-		for i := 0; i < actualLength; i++ {
+		for i := range actualLength {
 			assert.Equal(expected[i].Name, actual[i].Name)
 			assert.Equal(expected[i].ConfigFile, actual[i].ConfigFile)
 			assert.Equal(expected[i].TotalTests, actual[i].TotalTests)
@@ -72,7 +72,7 @@ func assertXUnitTestRun(assert *assert.Assertions, expected, actual []XUnitTestR
 		actualLength := len(actual)
 		assert.Equal(len(expected), actualLength)
 
-		for i := 0; i < actualLength; i++ {
+		for i := range actualLength {
 			assert.Equal(expected[i].Name, actual[i].Name)
 			assert.Equal(expected[i].TotalTests, actual[i].TotalTests)
 			assert.Equal(expected[i].PassedTests, actual[i].PassedTests)
@@ -94,7 +94,7 @@ func assertXUnitTestCase(assert *assert.Assertions, expected, actual []XUnitTest
 		actualLength := len(actual)
 		assert.Equal(len(expected), actualLength)
 
-		for i := 0; i < actualLength; i++ {
+		for i := range actualLength {
 			assert.Equal(expected[i].Name, actual[i].Name)
 			assert.Equal(expected[i].Type, actual[i].Type)
 			assert.Equal(expected[i].Method, actual[i].Method)

--- a/pkg/unittest/k8s_fake_client.go
+++ b/pkg/unittest/k8s_fake_client.go
@@ -18,7 +18,7 @@ type KubernetesFakeKindProps struct {
 
 type KubernetesFakeClientProvider struct {
 	Scheme  map[string]KubernetesFakeKindProps `yaml:"scheme"`
-	Objects []map[string]interface{}           `yaml:"objects"`
+	Objects []map[string]any                   `yaml:"objects"`
 }
 
 func (p *KubernetesFakeClientProvider) GetClientFor(apiVersion, kind string) (dynamic.NamespaceableResourceInterface, bool, error) {
@@ -30,7 +30,7 @@ func (p *KubernetesFakeClientProvider) GetClientFor(apiVersion, kind string) (dy
 	return fake.NewSimpleDynamicClient(runtime.NewScheme(), convertRuntimeObject(p.Objects)...).Resource(props.Gvr), props.Namespaced, nil
 }
 
-func convertRuntimeObject(input []map[string]interface{}) []runtime.Object {
+func convertRuntimeObject(input []map[string]any) []runtime.Object {
 	result := make([]runtime.Object, len(input))
 
 	for k, v := range input {

--- a/pkg/unittest/k8s_fake_client_test.go
+++ b/pkg/unittest/k8s_fake_client_test.go
@@ -11,11 +11,11 @@ import (
 	. "github.com/helm-unittest/helm-unittest/pkg/unittest"
 )
 
-func newMap(apiVersion, kind, namespace, name string) map[string]interface{} {
-	return map[string]interface{}{
+func newMap(apiVersion, kind, namespace, name string) map[string]any {
+	return map[string]any{
 		"apiVersion": apiVersion,
 		"kind":       kind,
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"namespace": namespace,
 			"name":      name,
 		},
@@ -25,7 +25,7 @@ func newMap(apiVersion, kind, namespace, name string) map[string]interface{} {
 func TestKubernetesFakeClientProvider(t *testing.T) {
 	k := KubernetesFakeClientProvider{
 		Scheme:  map[string]KubernetesFakeKindProps{"v1/Pod": {ShouldErr: nil, Gvr: schema.GroupVersionResource{Resource: "pods", Version: "v1"}, Namespaced: true}},
-		Objects: []map[string]interface{}{newMap("v1", "Pod", "default", "unittest")},
+		Objects: []map[string]any{newMap("v1", "Pod", "default", "unittest")},
 	}
 
 	client, namespaced, err := k.GetClientFor("v1", "Pod")

--- a/pkg/unittest/printer/printer.go
+++ b/pkg/unittest/printer/printer.go
@@ -63,48 +63,48 @@ func (p *Printer) setupColor(color *color.Color) {
 // Println print a line with indent level.
 func (p *Printer) Println(content string, indentLevel int) {
 	var indent string
-	for i := 0; i < indentLevel; i++ {
+	for range indentLevel {
 		indent += "\t"
 	}
 	_, _ = fmt.Fprintln(p.Writer, indent+content)
 }
 
 // Success print success.
-func (p *Printer) Success(format string, a ...interface{}) string {
+func (p *Printer) Success(format string, a ...any) string {
 	return p.colors.Success.Sprintf(format, a...)
 }
 
 // SuccessLabel print success as label.
-func (p *Printer) SuccessLabel(format string, a ...interface{}) string {
+func (p *Printer) SuccessLabel(format string, a ...any) string {
 	return p.colors.SuccessBg.Sprintf(format, a...)
 }
 
 // Danger print danger.
-func (p *Printer) Danger(format string, a ...interface{}) string {
+func (p *Printer) Danger(format string, a ...any) string {
 	return p.colors.Danger.Sprintf(format, a...)
 }
 
 // DangerLabel print danger as label.
-func (p *Printer) DangerLabel(format string, a ...interface{}) string {
+func (p *Printer) DangerLabel(format string, a ...any) string {
 	return p.colors.DangerBg.Sprintf(format, a...)
 }
 
 // Warning print warning.
-func (p *Printer) Warning(format string, a ...interface{}) string {
+func (p *Printer) Warning(format string, a ...any) string {
 	return p.colors.Warning.Sprintf(format, a...)
 }
 
 // WarningLabel print warning as label.
-func (p *Printer) WarningLabel(format string, a ...interface{}) string {
+func (p *Printer) WarningLabel(format string, a ...any) string {
 	return p.colors.WarningBg.Sprintf(format, a...)
 }
 
 // Highlight print highlight.
-func (p *Printer) Highlight(format string, a ...interface{}) string {
+func (p *Printer) Highlight(format string, a ...any) string {
 	return p.colors.Highlight.Sprintf(format, a...)
 }
 
 // Faint print faint.
-func (p *Printer) Faint(format string, a ...interface{}) string {
+func (p *Printer) Faint(format string, a ...any) string {
 	return p.colors.Faint.Sprintf(format, a...)
 }

--- a/pkg/unittest/snapshot/cache.go
+++ b/pkg/unittest/snapshot/cache.go
@@ -59,7 +59,7 @@ func (s *Cache) getCached(test string, idx uint) (string, bool) {
 }
 
 // Compare content to cached last time, return CompareResult
-func (s *Cache) Compare(test string, idx uint, content interface{}, optFns ...func(options *CacheOptions) error) *CompareResult {
+func (s *Cache) Compare(test string, idx uint, content any, optFns ...func(options *CacheOptions) error) *CompareResult {
 	var options CacheOptions
 	var err error
 	var msg string

--- a/pkg/unittest/snapshot/cache_test.go
+++ b/pkg/unittest/snapshot/cache_test.go
@@ -21,27 +21,27 @@ var lastTimeContent = `cached before:
 `
 
 var snapshot1 = "a:\n  b: c\n"
-var content1 = map[string]interface{}{
+var content1 = map[string]any{
 	"a": map[string]string{
 		"b": "c",
 	},
 }
 
 var snapshot2 = "d:\n  e: f\n"
-var content2 = map[string]interface{}{
+var content2 = map[string]any{
 	"d": map[string]string{
 		"e": "f",
 	},
 }
 
 var snapshotNew = "x:\n  \"y\": z\n"
-var contentNew = map[string]interface{}{
+var contentNew = map[string]any{
 	"x": map[string]string{
 		"y": "z",
 	},
 }
 
-var contentForRegex = map[string]interface{}{
+var contentForRegex = map[string]any{
 	"x": map[string]string{
 		"y": "abrakadabra",
 	},

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -55,15 +55,15 @@ type PostRendererConfig struct {
 func spliteChartRoutes(routePath string) []string {
 	splited := strings.Split(routePath, string(filepath.Separator))
 	routes := make([]string, len(splited)/2+1)
-	for r := 0; r < len(routes); r++ {
+	for r := range routes {
 		routes[r] = splited[r*2]
 	}
 	return routes
 }
 
-func scopeValuesWithRoutes(routes []string, values map[string]interface{}) map[string]interface{} {
+func scopeValuesWithRoutes(routes []string, values map[string]any) map[string]any {
 	if len(routes) > 1 {
-		newvalues := make(map[string]interface{})
+		newvalues := make(map[string]any)
 		if v, ok := values["global"]; ok {
 			newvalues["global"] = v
 		}
@@ -163,7 +163,7 @@ type orderedSnapshotComparer struct {
 	counter uint
 }
 
-func (s *orderedSnapshotComparer) CompareToSnapshot(content interface{}, optFns ...func(options *snapshot.CacheOptions) error) *snapshot.CompareResult {
+func (s *orderedSnapshotComparer) CompareToSnapshot(content any, optFns ...func(options *snapshot.CacheOptions) error) *snapshot.CompareResult {
 	s.counter++
 	return s.cache.Compare(s.test, s.counter, content, optFns...)
 }
@@ -175,13 +175,13 @@ type Capabilities struct {
 }
 
 // CapabilitiesFields required to identify where or not the filed is provided, and the value is unset or not
-type CapabilitiesFields map[string]interface{}
+type CapabilitiesFields map[string]any
 
 // TestJob definition of a test, including values and assertions
 type TestJob struct {
 	Name             string `yaml:"it"`
 	Values           []string
-	Set              map[string]interface{}
+	Set              map[string]any
 	Template         string
 	Templates        []string
 	DocumentIndex    *int `yaml:"documentIndex"`
@@ -207,7 +207,7 @@ type TestJob struct {
 	PostRendererConfig PostRendererConfig           `yaml:"postRenderer"`
 
 	// global set values
-	globalSet map[string]interface{}
+	globalSet map[string]any
 	// route indicate which chart in the dependency hierarchy
 	// like "parant-chart", "parent-charts/charts/child-chart"
 	chartRoute string
@@ -302,12 +302,12 @@ func (t *TestJob) RunV3(
 
 // liberally borrows from helm-template
 func (t *TestJob) getUserValues() (string, error) {
-	base := map[string]interface{}{}
+	base := map[string]any{}
 	routes := spliteChartRoutes(t.chartRoute)
 
 	// Load and merge values files.
 	for _, specifiedPath := range t.Values {
-		value := map[string]interface{}{}
+		value := map[string]any{}
 		var valueFilePath string
 		if filepath.IsAbs(specifiedPath) {
 			valueFilePath = specifiedPath
@@ -753,7 +753,7 @@ func (t *TestJob) SetCapabilities() {
 	}
 	if val, ok := t.CapabilitiesFields["apiVersions"]; ok {
 		switch v := val.(type) {
-		case []interface{}:
+		case []any:
 			t.Capabilities.APIVersions = make([]string, 0, len(v)) // optimize slice allocation
 			for _, item := range v {
 				if str, ok := item.(string); ok {
@@ -773,7 +773,7 @@ func (t *TestJob) SetCapabilities() {
 
 // ConvertIToString The convertToString function takes an interface{} value as input and returns a string representation of it.
 // If the input value is nil, it returns an empty string.
-func convertIToString(val interface{}) string {
+func convertIToString(val any) string {
 	if val == nil {
 		return ""
 	}

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -50,7 +50,7 @@ asserts:
 	a := assert.New(t)
 	a.Equal(tj.Name, "should do something")
 	a.Equal(tj.Values, []string{"values.yaml"})
-	a.Equal(tj.Set, map[string]interface{}{
+	a.Equal(tj.Set, map[string]any{
 		"a.b.c": "ABC",
 		"x.y.z": "XYZ",
 	})
@@ -1025,7 +1025,7 @@ func TestV3RunJob_TplFunction_Fail_WithoutAssertion(t *testing.T) {
 			Version: "1.2.3",
 		},
 		Templates: []*v3chart.File{},
-		Values:    map[string]interface{}{},
+		Values:    map[string]any{},
 	}
 
 	tests := []struct {
@@ -1064,7 +1064,7 @@ func TestV3RunJob_TplFunction_Fail_WithAssertion(t *testing.T) {
 			Version: "1.2.3",
 		},
 		Templates: []*v3chart.File{},
-		Values:    map[string]interface{}{},
+		Values:    map[string]any{},
 	}
 
 	tests := []struct {

--- a/pkg/unittest/test_runner_test.go
+++ b/pkg/unittest/test_runner_test.go
@@ -22,7 +22,7 @@ import (
 var sectionBeginPattern = regexp.MustCompile("( PASS | FAIL |\n*###|\n*Charts:|\n*Snapshot Summary:)")
 var timePattern = regexp.MustCompile(`(Time:\s+)(?:[\d\.]+)(s|ms|\xB5s)`) // B5 = micron for microseconds
 
-func makeOutputSnapshotable(originalOutput string) []interface{} {
+func makeOutputSnapshotable(originalOutput string) []any {
 	output := strings.ReplaceAll(originalOutput, "\\", "/")
 	timeAgnosticOutput := timePattern.ReplaceAllString(output, "${1}XX.XXXms")
 
@@ -30,7 +30,7 @@ func makeOutputSnapshotable(originalOutput string) []interface{} {
 	sections := make([]string, len(sectionBeggingLocs))
 
 	suiteBeginIdx := -1
-	for sectionIdx := 0; sectionIdx < len(sections); sectionIdx++ {
+	for sectionIdx := range sections {
 		start := sectionBeggingLocs[sectionIdx][0]
 		var end int
 		if sectionIdx >= len(sections)-1 {
@@ -55,7 +55,7 @@ func makeOutputSnapshotable(originalOutput string) []interface{} {
 		}
 	}
 
-	sectionsToRetrun := make([]interface{}, len(sections))
+	sectionsToRetrun := make([]any, len(sections))
 	for idx, section := range sections {
 		sectionsToRetrun[idx] = section
 	}

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -109,7 +110,7 @@ func createTestSuite(suiteFilePath string, chartRoute string, content string, st
 }
 
 // RenderTestSuiteFiles renders a helm suite of test files and returns their TestSuites
-func RenderTestSuiteFiles(helmTestSuiteDir string, chartRoute string, strict bool, valueFilesSet []string, renderValues map[string]interface{}) ([]*TestSuite, error) {
+func RenderTestSuiteFiles(helmTestSuiteDir string, chartRoute string, strict bool, valueFilesSet []string, renderValues map[string]any) ([]*TestSuite, error) {
 	testChartPath := filepath.Join(helmTestSuiteDir, "Chart.yaml")
 	// Ensure there's a helm file
 	if _, err := os.Stat(testChartPath); err != nil {
@@ -208,7 +209,7 @@ func iterateTemplates(template string, suites []*TestSuite, absPath string, char
 type TestSuite struct {
 	Name             string `yaml:"suite"`
 	Values           []string
-	Set              map[string]interface{}
+	Set              map[string]any
 	Templates        []string
 	ExcludeTemplates []string `yaml:"excludeTemplates"`
 	Release          struct {
@@ -357,9 +358,7 @@ func (s *TestSuite) polishKubernetesProviderSettings(test *TestJob) {
 		if test.KubernetesProvider.Scheme == nil {
 			test.KubernetesProvider.Scheme = map[string]KubernetesFakeKindProps{}
 		}
-		for k, v := range s.KubernetesProvider.Scheme {
-			test.KubernetesProvider.Scheme[k] = v
-		}
+		maps.Copy(test.KubernetesProvider.Scheme, s.KubernetesProvider.Scheme)
 	}
 }
 

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -291,7 +291,7 @@ func TestV3ParseTestSuiteFileWithOverrideValuesOk(t *testing.T) {
 
 func TestV3RenderSuitesUnstrictFileOk(t *testing.T) {
 	a := assert.New(t)
-	suites, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart", "basic", false, []string{}, map[string]interface{}{
+	suites, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart", "basic", false, []string{}, map[string]any{
 		"unexpectedField": false,
 	})
 
@@ -310,7 +310,7 @@ func TestV3RenderSuitesUnstrictFileOk(t *testing.T) {
 
 func TestV3RenderSuitesStrictFileFail(t *testing.T) {
 	a := assert.New(t)
-	_, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart", "basic", true, []string{}, map[string]interface{}{
+	_, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart", "basic", true, []string{}, map[string]any{
 		"unexpectedField": true,
 	})
 
@@ -320,7 +320,7 @@ func TestV3RenderSuitesStrictFileFail(t *testing.T) {
 
 func TestV3RenderSuites_InvalidDirectory(t *testing.T) {
 	a := assert.New(t)
-	_, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart-not-exist", "basic", true, []string{}, map[string]interface{}{
+	_, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart-not-exist", "basic", true, []string{}, map[string]any{
 		"unexpectedField": true,
 	})
 	a.Error(err)
@@ -384,7 +384,7 @@ version: 1.0.0
 	a.NoError(writeToFile(chart, path.Join(chartPath, "Chart.yaml")))
 	a.NoError(writeToFile(empty_manifest, path.Join(chartPath, "templates/deployment.yaml")))
 	defer os.RemoveAll(chartPath)
-	values := map[string]interface{}{
+	values := map[string]any{
 		"key1": "value1",
 		"key2": "value2",
 	}
@@ -395,7 +395,7 @@ version: 1.0.0
 
 func TestV3RenderSuitesFailNoSuiteName(t *testing.T) {
 	a := assert.New(t)
-	_, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart", "basic", true, []string{}, map[string]interface{}{
+	_, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart", "basic", true, []string{}, map[string]any{
 		"includeSuite": false,
 	})
 	a.NotNil(err)
@@ -421,7 +421,7 @@ func TestV3RenderSuitesStrictFileOk(t *testing.T) {
 
 func TestV3RenderSuitesCustomSnapshotIdOk(t *testing.T) {
 	a := assert.New(t)
-	suites, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart", "basic", true, []string{}, map[string]interface{}{
+	suites, err := RenderTestSuiteFiles("../../test/data/v3/with-helm-tests/tests-chart", "basic", true, []string{}, map[string]any{
 		"customSnapshotIds": true,
 	})
 

--- a/pkg/unittest/validators/common.go
+++ b/pkg/unittest/validators/common.go
@@ -22,7 +22,7 @@ var regex = regexp.MustCompile(`(?m)[ ]+\r?\n`)
 
 // SnapshotComparer provide CompareToSnapshot utility to validator
 type SnapshotComparer interface {
-	CompareToSnapshot(content interface{}, optFns ...func(options *snapshot.CacheOptions) error) *snapshot.CompareResult
+	CompareToSnapshot(content any, optFns ...func(options *snapshot.CacheOptions) error) *snapshot.CompareResult
 }
 
 // ValidateContext the context passed to validators
@@ -80,7 +80,7 @@ Expected` + notAnnotation + customize + `:
 // splitInfof split multi line string into array of string
 func splitInfof(format string, manifestIndex, valuesIndex int, replacements ...string) []string {
 	intentedFormat := strings.Trim(format, "\t\n ")
-	indentedReplacements := make([]interface{}, len(replacements))
+	indentedReplacements := make([]any, len(replacements))
 	for i, r := range replacements {
 		indentedReplacements[i] = "\t" + strings.Trim(
 			strings.Replace(r, "\n", "\n\t", -1),
@@ -123,13 +123,13 @@ func diff(expected string, actual string) string {
 }
 
 // uniform the content without invalid characters and correct line-endings
-func uniformContent(content interface{}) string {
+func uniformContent(content any) string {
 	actual := fmt.Sprintf("%v", content)
 	return regex.ReplaceAllString(actual, "\n")
 }
 
 // Validate a subset, which are used for SubsetValidator and Contains (when Any option is used)
-func validateSubset(actual map[string]interface{}, content map[string]interface{}) bool {
+func validateSubset(actual map[string]any, content map[string]any) bool {
 	for key := range content {
 		if !reflect.DeepEqual(actual[key], content[key]) {
 			return false

--- a/pkg/unittest/validators/common_test.go
+++ b/pkg/unittest/validators/common_test.go
@@ -14,7 +14,7 @@ type mockSnapshotComparer struct {
 	mock.Mock
 }
 
-func (m *mockSnapshotComparer) CompareToSnapshot(content interface{}, optFns ...func(options *snapshot.CacheOptions) error) *snapshot.CompareResult {
+func (m *mockSnapshotComparer) CompareToSnapshot(content any, optFns ...func(options *snapshot.CacheOptions) error) *snapshot.CompareResult {
 	args := m.Called(content)
 	return args.Get(0).(*snapshot.CompareResult)
 }

--- a/pkg/unittest/validators/contains_document_validator.go
+++ b/pkg/unittest/validators/contains_document_validator.go
@@ -20,7 +20,7 @@ type ContainsDocumentValidator struct {
 	Any        bool   // optional
 }
 
-func (v ContainsDocumentValidator) failInfo(actual interface{}, manifestIndex, assertIndex int, not bool) []string {
+func (v ContainsDocumentValidator) failInfo(actual any, manifestIndex, assertIndex int, not bool) []string {
 
 	log.WithField("validator", "contains_document").Debugln("index content:", manifestIndex)
 	log.WithField("validator", "contains_document").Debugln("actual content:", actual)

--- a/pkg/unittest/validators/contains_validator.go
+++ b/pkg/unittest/validators/contains_validator.go
@@ -13,13 +13,13 @@ import (
 // ContainsValidator validate whether value of Path is an array and contains Content
 type ContainsValidator struct {
 	Path    string
-	Content interface{}
+	Content any
 	Count   *int
 	Any     bool
 }
 
-func (v ContainsValidator) failInfo(actual interface{}, manifestIndex, assertIndex int, not bool) []string {
-	expectedYAML := common.TrustedMarshalYAML([]interface{}{v.Content})
+func (v ContainsValidator) failInfo(actual any, manifestIndex, assertIndex int, not bool) []string {
+	expectedYAML := common.TrustedMarshalYAML([]any{v.Content})
 	actualYAML := common.TrustedMarshalYAML(actual)
 	containsFailFormat := setFailFormat(not, true, true, false, " to contain")
 
@@ -36,7 +36,7 @@ func (v ContainsValidator) failInfo(actual interface{}, manifestIndex, assertInd
 	)
 }
 
-func (v ContainsValidator) validateContent(actual []interface{}) (bool, int) {
+func (v ContainsValidator) validateContent(actual []any) (bool, int) {
 	found := false
 	validateFoundCount := 0
 
@@ -56,10 +56,10 @@ func (v ContainsValidator) validateContent(actual []interface{}) (bool, int) {
 	return found, validateFoundCount
 }
 
-func (v ContainsValidator) isArrayOrSubsetMatch(ele interface{}) (bool, bool) {
+func (v ContainsValidator) isArrayOrSubsetMatch(ele any) (bool, bool) {
 	if v.Any {
-		subset, subsetOk := ele.(map[string]interface{})
-		content, contentOk := v.Content.(map[string]interface{})
+		subset, subsetOk := ele.(map[string]any)
+		content, contentOk := v.Content.(map[string]any)
 		if subsetOk && contentOk {
 			return false, validateSubset(subset, content)
 		} else {
@@ -70,7 +70,7 @@ func (v ContainsValidator) isArrayOrSubsetMatch(ele interface{}) (bool, bool) {
 	return false, false
 }
 
-func (v ContainsValidator) isExactMatch(isArray bool, ele interface{}) bool {
+func (v ContainsValidator) isExactMatch(isArray bool, ele any) bool {
 	return (!v.Any || isArray) && reflect.DeepEqual(ele, v.Content)
 }
 
@@ -78,7 +78,7 @@ func (v ContainsValidator) validateFoundCount(validateFoundCount int) bool {
 	return v.Count != nil && *v.Count == validateFoundCount
 }
 
-func (v ContainsValidator) validateSingle(singleActual []interface{}, manifestIndex, assertIndex int, context *ValidateContext) (bool, []string) {
+func (v ContainsValidator) validateSingle(singleActual []any, manifestIndex, assertIndex int, context *ValidateContext) (bool, []string) {
 	validateSingleErrors := []string{}
 	found, validateFoundCount := v.validateContent(singleActual)
 
@@ -123,7 +123,7 @@ func (v ContainsValidator) validateManifest(manifest common.K8sManifest, manifes
 	for valuesIndex, singleActual := range actual {
 		singleSuccess := false
 		var singleValidateErrors []string
-		convertedSingleActual, ok := singleActual.([]interface{})
+		convertedSingleActual, ok := singleActual.([]any)
 		if ok {
 			singleSuccess, singleValidateErrors = v.validateSingle(convertedSingleActual, manifestIndex, valuesIndex, context)
 		} else {

--- a/pkg/unittest/validators/contains_validator_test.go
+++ b/pkg/unittest/validators/contains_validator_test.go
@@ -36,7 +36,7 @@ func TestContainsValidatorWhenOk(t *testing.T) {
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 		nil,
 		false,
 	}
@@ -51,7 +51,7 @@ func TestContainsValidatorWhenOk(t *testing.T) {
 func TestContainsValidatorWhenEmptyManifestFail(t *testing.T) {
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 		nil,
 		false,
 	}
@@ -70,7 +70,7 @@ func TestContainsValidatorWhenEmptyManifestFail(t *testing.T) {
 func TestContainsValidatorWhenEmptyManifestNegativeOk(t *testing.T) {
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 		nil,
 		false,
 	}
@@ -95,7 +95,7 @@ a:
 
 	validator := ContainsValidator{
 		"$.*",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 		nil,
 		false,
 	}
@@ -113,7 +113,7 @@ func TestMultiManifestContainsValidatorWhenOk(t *testing.T) {
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 		nil,
 		false,
 	}
@@ -184,7 +184,7 @@ a:
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"name": "VALUE1"},
+		map[string]any{"name": "VALUE1"},
 		nil,
 		true,
 	}
@@ -212,7 +212,7 @@ a:
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"name": "VALUE3"},
+		map[string]any{"name": "VALUE3"},
 		nil,
 		true,
 	}
@@ -251,7 +251,7 @@ a:
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"name": "VALUE3"},
+		map[string]any{"name": "VALUE3"},
 		nil,
 		true,
 	}
@@ -297,7 +297,7 @@ a:
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"name": "VALUE3"},
+		map[string]any{"name": "VALUE3"},
 		nil,
 		true,
 	}
@@ -326,7 +326,7 @@ func TestContainsValidatorWhenNegativeAndOk(t *testing.T) {
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"d": "hello bar"},
+		map[string]any{"d": "hello bar"},
 		nil,
 		false,
 	}
@@ -344,7 +344,7 @@ func TestContainsValidatorWhenFail(t *testing.T) {
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"e": "bar bar"},
+		map[string]any{"e": "bar bar"},
 		nil,
 		false,
 	}
@@ -379,7 +379,7 @@ a:
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 		nil,
 		false,
 	}
@@ -405,7 +405,7 @@ func TestContainsValidatorMultiManifestWhenBothFail(t *testing.T) {
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"e": "foo bar"},
+		map[string]any{"e": "foo bar"},
 		nil,
 		false,
 	}
@@ -443,7 +443,7 @@ func TestContainsValidatorWhenNegativeAndFail(t *testing.T) {
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 		nil,
 		false,
 	}
@@ -473,7 +473,7 @@ func TestContainsValidatorMultiDocsWhenNegativeAndFail(t *testing.T) {
 
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 		nil,
 		false,
 	}
@@ -637,7 +637,7 @@ func TestContainsValidatorWhenMultipleTimesInArray(t *testing.T) {
 	counter := 2
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"e": "bar"},
+		map[string]any{"e": "bar"},
 		&counter,
 		false,
 	}
@@ -655,7 +655,7 @@ func TestContainsValidatorInverseWhenNotMultipleTimesInArray(t *testing.T) {
 	counter := 1
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"e": "bar"},
+		map[string]any{"e": "bar"},
 		&counter,
 		false,
 	}
@@ -674,7 +674,7 @@ func TestContainsValidatorWhenNotMultipleTimesInArray(t *testing.T) {
 	counter := 1
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"e": "bar"},
+		map[string]any{"e": "bar"},
 		&counter,
 		false,
 	}
@@ -701,7 +701,7 @@ func TestContainsValidatorWhenNotFoundMultipleTimesInArray(t *testing.T) {
 	counter := 1
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"f": "bar"},
+		map[string]any{"f": "bar"},
 		&counter,
 		false,
 	}
@@ -730,7 +730,7 @@ func TestContainsValidatorInverseWhenNotFoundMultipleTimesInArray(t *testing.T) 
 	counter := 1
 	validator := ContainsValidator{
 		"a.b",
-		map[string]interface{}{"f": "bar"},
+		map[string]any{"f": "bar"},
 		&counter,
 		false,
 	}

--- a/pkg/unittest/validators/equal_or_greater_validator.go
+++ b/pkg/unittest/validators/equal_or_greater_validator.go
@@ -3,7 +3,7 @@ package validators
 // EqualOrGreaterValidator validate whether the value of Path is greater or equal to Value
 type EqualOrGreaterValidator struct {
 	Path  string
-	Value interface{}
+	Value any
 }
 
 // Validate implement Validatable

--- a/pkg/unittest/validators/equal_or_greater_validator_test.go
+++ b/pkg/unittest/validators/equal_or_greater_validator_test.go
@@ -13,7 +13,7 @@ func TestEqualOrGreaterValidatorOk(t *testing.T) {
 		name        string
 		doc         string
 		path        string
-		value       interface{}
+		value       any
 		expected    bool
 		expectedErr []string
 	}{
@@ -61,7 +61,7 @@ func TestEqualOrGreaterValidatorOk(t *testing.T) {
 func TestEqualOrGreaterValidatorFail(t *testing.T) {
 	tests := []struct {
 		name, doc, path string
-		value           interface{}
+		value           any
 		errorMsg        []string
 	}{
 		{
@@ -221,7 +221,7 @@ spec:
 func TestEqualOrGreaterValidatorWhenTypesDoNotMatch(t *testing.T) {
 	tests := []struct {
 		name, doc, path string
-		value           interface{}
+		value           any
 		errorMsg        []string
 	}{
 		{
@@ -268,7 +268,7 @@ func TestEqualOrGreaterValidatorWhenTypesDoNotMatch(t *testing.T) {
 func TestEqualOrGreaterValidatorWhenTypesDoNotMatchFailFast(t *testing.T) {
 	tests := []struct {
 		name, doc, path string
-		value           interface{}
+		value           any
 		errorMsg        []string
 	}{
 		{

--- a/pkg/unittest/validators/equal_or_less_validator.go
+++ b/pkg/unittest/validators/equal_or_less_validator.go
@@ -3,7 +3,7 @@ package validators
 // EqualOrLessValidator validate whether the value of Path is less or equal to Value
 type EqualOrLessValidator struct {
 	Path  string
-	Value interface{}
+	Value any
 }
 
 // Validate implement Validatable

--- a/pkg/unittest/validators/equal_or_less_validator_test.go
+++ b/pkg/unittest/validators/equal_or_less_validator_test.go
@@ -13,7 +13,7 @@ func TestEqualOrLessValidatorOk(t *testing.T) {
 		name        string
 		doc         string
 		path        string
-		value       interface{}
+		value       any
 		expected    bool
 		expectedErr []string
 	}{
@@ -61,7 +61,7 @@ func TestEqualOrLessValidatorOk(t *testing.T) {
 func TestEqualOrLessValidatorFail(t *testing.T) {
 	tests := []struct {
 		name, doc, path string
-		value           interface{}
+		value           any
 		errorMsg        []string
 	}{
 		{

--- a/pkg/unittest/validators/equal_raw_validator.go
+++ b/pkg/unittest/validators/equal_raw_validator.go
@@ -13,7 +13,7 @@ type EqualRawValidator struct {
 	Value string
 }
 
-func (a EqualRawValidator) failInfo(actual interface{}, not bool) []string {
+func (a EqualRawValidator) failInfo(actual any, not bool) []string {
 	expectedYAML := common.TrustedMarshalYAML(a.Value)
 	actualYAML := common.TrustedMarshalYAML(actual)
 	customMessage := " to equal"

--- a/pkg/unittest/validators/equal_validator.go
+++ b/pkg/unittest/validators/equal_validator.go
@@ -14,11 +14,11 @@ import (
 // EqualValidator validate whether the value of Path equal to Value
 type EqualValidator struct {
 	Path         string
-	Value        interface{}
+	Value        any
 	DecodeBase64 bool `yaml:"decodeBase64"`
 }
 
-func (a EqualValidator) failInfo(actual interface{}, manifestIndex, actualIndex int, not bool) []string {
+func (a EqualValidator) failInfo(actual any, manifestIndex, actualIndex int, not bool) []string {
 	expectedYAML := common.TrustedMarshalYAML(a.Value)
 	actualYAML := common.TrustedMarshalYAML(actual)
 	customMessage := " to equal"
@@ -72,7 +72,7 @@ func (a EqualValidator) validateManifest(manifest common.K8sManifest, manifestIn
 	return validateManifestSuccess, validateManifestErrors
 }
 
-func (a EqualValidator) validateSingleActual(actual interface{}, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
+func (a EqualValidator) validateSingleActual(actual any, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
 	if s, ok := actual.(string); ok {
 		if a.DecodeBase64 {
 			decodedSingleActual, err := base64.StdEncoding.DecodeString(s)

--- a/pkg/unittest/validators/equal_validator_test.go
+++ b/pkg/unittest/validators/equal_validator_test.go
@@ -109,7 +109,7 @@ func TestEqualValidatorWhenFail(t *testing.T) {
 
 	validator := EqualValidator{
 		"a.b[0]",
-		map[interface{}]interface{}{"d": 321},
+		map[any]any{"d": 321},
 		false,
 	}
 	pass, diff := validator.Validate(&ValidateContext{
@@ -145,7 +145,7 @@ a:
 
 	validator := EqualValidator{
 		"a.b[0]",
-		map[string]interface{}{"c": 321},
+		map[string]any{"c": 321},
 		false,
 	}
 	pass, diff := validator.Validate(&ValidateContext{
@@ -175,7 +175,7 @@ func TestEqualValidatorMultiManifestWhenBothFail(t *testing.T) {
 
 	validator := EqualValidator{
 		"a.b[0]",
-		map[string]interface{}{"c": 321},
+		map[string]any{"c": 321},
 		false,
 	}
 	pass, diff := validator.Validate(&ValidateContext{
@@ -216,7 +216,7 @@ func TestEqualValidatorMultiManifestWhenBothFail(t *testing.T) {
 func TestEqualValidatorWhenNegativeAndFail(t *testing.T) {
 	manifest := makeManifest(docToTestEqual)
 
-	v := EqualValidator{"a.b[0]", map[string]interface{}{"c": 123}, false}
+	v := EqualValidator{"a.b[0]", map[string]any{"c": 123}, false}
 	pass, diff := v.Validate(&ValidateContext{
 		Docs:     []common.K8sManifest{manifest},
 		Negative: true,

--- a/pkg/unittest/validators/failed_template_validator.go
+++ b/pkg/unittest/validators/failed_template_validator.go
@@ -21,7 +21,7 @@ type FailedTemplateValidator struct {
 	ErrorPattern string
 }
 
-func (a FailedTemplateValidator) failInfo(actual interface{}, manifestIndex, actualIndex int, not bool) []string {
+func (a FailedTemplateValidator) failInfo(actual any, manifestIndex, actualIndex int, not bool) []string {
 	customMessage := " to equal"
 	if a.ErrorPattern != "" {
 		customMessage = " to match"
@@ -90,7 +90,7 @@ func (a FailedTemplateValidator) validateManifests(manifests []common.K8sManifes
 	return validateSuccess, validateErrors
 }
 
-func (a FailedTemplateValidator) validateErrorPattern(actual interface{}, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
+func (a FailedTemplateValidator) validateErrorPattern(actual any, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
 	p, err := compilePattern(a.ErrorPattern)
 	if err != nil {
 		return false, splitInfof(errorFormat, -1, -1, err.Error())
@@ -114,7 +114,7 @@ func compilePattern(pattern string) (*regexp.Regexp, error) {
 	return p, err
 }
 
-func handleMetaCharacters(a FailedTemplateValidator, actual interface{}, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
+func handleMetaCharacters(a FailedTemplateValidator, actual any, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
 	escaped := regexp.QuoteMeta(a.ErrorPattern)
 	log.WithField("validator", "failed_template").Debugln("fallback to escaped regex", escaped)
 	p, err := regexp.Compile(escaped)
@@ -128,7 +128,7 @@ func handleMetaCharacters(a FailedTemplateValidator, actual interface{}, manifes
 	return true, []string{}
 }
 
-func (a FailedTemplateValidator) validateErrorMessage(actual interface{}, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
+func (a FailedTemplateValidator) validateErrorMessage(actual any, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
 	if (actual != nil && reflect.DeepEqual(a.ErrorMessage, actual.(string))) == context.Negative {
 		errorMessage := a.failInfo(actual, manifestIndex, actualIndex, context.Negative)
 		return false, errorMessage

--- a/pkg/unittest/validators/failed_template_validator_test.go
+++ b/pkg/unittest/validators/failed_template_validator_test.go
@@ -375,7 +375,7 @@ func TestFailedTemplateValidator_ErrorPattern_SpecialCharactersAndEscapes_Diff(t
 	cases := []struct {
 		name    string
 		pattern string
-		diff    interface{}
+		diff    any
 	}{
 		{
 			name:    "pattern with incorrect regex escape",

--- a/pkg/unittest/validators/is_apiversion_validator.go
+++ b/pkg/unittest/validators/is_apiversion_validator.go
@@ -11,7 +11,7 @@ type IsAPIVersionValidator struct {
 	Of string
 }
 
-func (v IsAPIVersionValidator) failInfo(actual interface{}, manifestIndex, actualIndex int, not bool) []string {
+func (v IsAPIVersionValidator) failInfo(actual any, manifestIndex, actualIndex int, not bool) []string {
 	actualYAML := common.TrustedMarshalYAML(actual)
 	customMessage := " to be apiVersion"
 

--- a/pkg/unittest/validators/is_kind_validator.go
+++ b/pkg/unittest/validators/is_kind_validator.go
@@ -10,7 +10,7 @@ type IsKindValidator struct {
 	Of string
 }
 
-func (v IsKindValidator) failInfo(actual interface{}, manifestIndex, actualIndex int, not bool) []string {
+func (v IsKindValidator) failInfo(actual any, manifestIndex, actualIndex int, not bool) []string {
 	actualYAML := common.TrustedMarshalYAML(actual)
 	customMessage := " to be kind"
 

--- a/pkg/unittest/validators/is_nullorempty_validator.go
+++ b/pkg/unittest/validators/is_nullorempty_validator.go
@@ -15,7 +15,7 @@ type IsNullOrEmptyValidator struct {
 	Path string
 }
 
-func (v IsNullOrEmptyValidator) failInfo(actual interface{}, manifestIndex, actualIndex int, not bool) []string {
+func (v IsNullOrEmptyValidator) failInfo(actual any, manifestIndex, actualIndex int, not bool) []string {
 	actualYAML := common.TrustedMarshalYAML(actual)
 
 	log.WithField("validator", "is_nullorempty").Debugln("actual content:", actualYAML)

--- a/pkg/unittest/validators/is_subset_validator.go
+++ b/pkg/unittest/validators/is_subset_validator.go
@@ -11,10 +11,10 @@ import (
 // IsSubsetValidator validate whether value of Path contains Content
 type IsSubsetValidator struct {
 	Path    string
-	Content interface{}
+	Content any
 }
 
-func (v IsSubsetValidator) failInfo(actual interface{}, manifestIndex, valueIndex int, not bool) []string {
+func (v IsSubsetValidator) failInfo(actual any, manifestIndex, valueIndex int, not bool) []string {
 	expectedYAML := common.TrustedMarshalYAML(v.Content)
 	actualYAML := common.TrustedMarshalYAML(actual)
 
@@ -46,8 +46,8 @@ func (v IsSubsetValidator) validateManifest(manifest common.K8sManifest, manifes
 
 	for actualIndex, singleActual := range actual {
 		var errorMessage []string
-		actualMap, actualOk := singleActual.(map[string]interface{})
-		contentMap, contentOk := v.Content.(map[string]interface{})
+		actualMap, actualOk := singleActual.(map[string]any)
+		contentMap, contentOk := v.Content.(map[string]any)
 
 		if actualOk && contentOk {
 			found := validateSubset(actualMap, contentMap)

--- a/pkg/unittest/validators/is_subset_validator_test.go
+++ b/pkg/unittest/validators/is_subset_validator_test.go
@@ -22,7 +22,7 @@ func TestIsSubsetValidatorWhenOk(t *testing.T) {
 
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar", "x": "baz"}}
+		map[string]any{"d": "foo bar", "x": "baz"}}
 
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs: []common.K8sManifest{manifest},
@@ -37,7 +37,7 @@ func TestIsSubsetValidatorWhenNegativeAndOk(t *testing.T) {
 
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"d": "hello bar", "c": "hello world"}}
+		map[string]any{"d": "hello bar", "c": "hello world"}}
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs:     []common.K8sManifest{manifest},
 		Negative: true,
@@ -54,7 +54,7 @@ func TestIsSubsetValidatorWhenFail(t *testing.T) {
 
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"e": "bar bar"},
+		map[string]any{"e": "bar bar"},
 	}
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs: []common.K8sManifest{manifest},
@@ -86,7 +86,7 @@ a:
 
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 	}
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs: manifests,
@@ -110,7 +110,7 @@ func TestIsSubsetValidatorMultiManifestWhenBothFail(t *testing.T) {
 
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"e": "foo bar"},
+		map[string]any{"e": "foo bar"},
 	}
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs: manifests,
@@ -144,7 +144,7 @@ func TestIsSubsetValidatorWhenNegativeAndFail(t *testing.T) {
 
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"d": "foo bar"},
+		map[string]any{"d": "foo bar"},
 	}
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs:     []common.K8sManifest{manifest},
@@ -300,7 +300,7 @@ func TestIsSubsetValidatorWhenFailFast(t *testing.T) {
 
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"e": "bar bar"},
+		map[string]any{"e": "bar bar"},
 	}
 	pass, diff := validator.Validate(&ValidateContext{
 		FailFast: true,
@@ -324,7 +324,7 @@ func TestIsSubsetValidatorWhenFailFast(t *testing.T) {
 func TestIsSubsetValidatorWhenNoManifestFail(t *testing.T) {
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"e": "bar bar"},
+		map[string]any{"e": "bar bar"},
 	}
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs: []common.K8sManifest{},
@@ -343,7 +343,7 @@ func TestIsSubsetValidatorWhenNoManifestFail(t *testing.T) {
 func TestIsSubsetValidatorWhenNoManifestNegativeOk(t *testing.T) {
 	validator := IsSubsetValidator{
 		"a.b",
-		map[string]interface{}{"e": "bar bar"},
+		map[string]any{"e": "bar bar"},
 	}
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs:     []common.K8sManifest{},

--- a/pkg/unittest/validators/length_equal_document_validator.go
+++ b/pkg/unittest/validators/length_equal_document_validator.go
@@ -40,7 +40,7 @@ func (v LengthEqualDocumentsValidator) singleValidateCounts(manifest common.K8sM
 
 	for actualIndex, actual := range actuals {
 		actualSuccess := false
-		actualArray, ok := actual.([]interface{})
+		actualArray, ok := actual.([]any)
 		if !ok && v.Count == nil {
 			actualErrors := splitInfof(errorFormat, manifestIndex, actualIndex, fmt.Sprintf("%s is not array", path))
 			manifestErrors = append(manifestErrors, actualErrors...)

--- a/pkg/unittest/validators/match_regex_validator.go
+++ b/pkg/unittest/validators/match_regex_validator.go
@@ -32,7 +32,7 @@ func (v MatchRegexValidator) failInfo(actual string, manifestIndex, actualIndex 
 	)
 }
 
-func (v MatchRegexValidator) validateSingle(actual interface{}, pattern *regexp.Regexp, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
+func (v MatchRegexValidator) validateSingle(actual any, pattern *regexp.Regexp, manifestIndex, actualIndex int, context *ValidateContext) (bool, []string) {
 	if s, ok := actual.(string); ok {
 		if v.DecodeBase64 {
 			decodedSingleActual, err := base64.StdEncoding.DecodeString(s)

--- a/pkg/unittest/validators/operator_validator.go
+++ b/pkg/unittest/validators/operator_validator.go
@@ -13,7 +13,7 @@ import (
 // internal struct, not exposed to end user
 type operatorValidator struct {
 	Path           string
-	Value          interface{}
+	Value          any
 	ComparisonType string
 }
 
@@ -33,7 +33,7 @@ func (o operatorValidator) failInfo(msg, comparisonType string, manifestIndex, a
 // ensuring that they are of compatible types and that the actual value is greater, less than or equal to the expected value.
 // If successful, it returns true along with a nil error slice. If unsuccessful, it returns false
 // along with an error slice containing information about the validation failure.
-func (o operatorValidator) compareValues(expected, actual interface{}, comparisonType string, negative bool) (bool, []string) {
+func (o operatorValidator) compareValues(expected, actual any, comparisonType string, negative bool) (bool, []string) {
 	expStr := fmt.Sprintf("%v", expected)
 	actStr := fmt.Sprintf("%v", actual)
 	result := false

--- a/pkg/unittest/valueutils/documentselector.go
+++ b/pkg/unittest/valueutils/documentselector.go
@@ -12,10 +12,10 @@ type DocumentSelector struct {
 	SkipEmptyTemplates bool `yaml:"skipEmptyTemplates"`
 	MatchMany          bool `yaml:"matchMany"`
 	Path               string
-	Value              interface{}
+	Value              any
 }
 
-func NewDocumentSelector(documentSelector map[string]interface{}) (*DocumentSelector, error) {
+func NewDocumentSelector(documentSelector map[string]any) (*DocumentSelector, error) {
 	path, ok := documentSelector["path"].(string)
 	if !ok {
 		log.WithField("selector", "document-selector").Debugln("documentSelector.path is empty")

--- a/pkg/unittest/valueutils/documentselector_test.go
+++ b/pkg/unittest/valueutils/documentselector_test.go
@@ -84,7 +84,7 @@ func TestFindDocumentIndexObjectValueOk(t *testing.T) {
 
 	selector := DocumentSelector{
 		Path: "metadata",
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"name":      "foo",
 			"namespace": "bar",
 		},
@@ -198,12 +198,12 @@ func TestFindDocumentIndicesMatchManyAndDontSkipEmptyTemplatesNOk(t *testing.T) 
 func TestNewSafeDocumentSelector_Success(t *testing.T) {
 	tests := []struct {
 		name             string
-		input            map[string]interface{}
+		input            map[string]any
 		expectedSelector *DocumentSelector
 	}{
 		{
 			name: "all fields set",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"path":               "metadata.name",
 				"value":              "foo",
 				"matchMany":          true,
@@ -218,7 +218,7 @@ func TestNewSafeDocumentSelector_Success(t *testing.T) {
 		},
 		{
 			name: "only required fields set",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"path": "metadata.name",
 			},
 			expectedSelector: &DocumentSelector{
@@ -240,7 +240,7 @@ func TestNewSafeDocumentSelector_Success(t *testing.T) {
 }
 
 func TestNewDocumentSelectorMissingPath(t *testing.T) {
-	input := map[string]interface{}{}
+	input := map[string]any{}
 	selector, err := NewDocumentSelector(input)
 	assert.NotNil(t, err)
 	assert.Nil(t, selector)

--- a/pkg/unittest/valueutils/valueutils.go
+++ b/pkg/unittest/valueutils/valueutils.go
@@ -12,8 +12,8 @@ import (
 )
 
 // GetValueOfSetPath get the value of the `--set` format path from a manifest
-func GetValueOfSetPath(manifest common.K8sManifest, path string) ([]interface{}, error) {
-	manifestResult := make([]interface{}, 0)
+func GetValueOfSetPath(manifest common.K8sManifest, path string) ([]any, error) {
+	manifestResult := make([]any, 0)
 	if path == "" {
 		return append(manifestResult, manifest), nil
 	}
@@ -49,7 +49,7 @@ func GetValueOfSetPath(manifest common.K8sManifest, path string) ([]interface{},
 	}
 
 	for _, node := range manifestParts {
-		var singleResult interface{}
+		var singleResult any
 		if err := node.Decode(&singleResult); err != nil {
 			return nil, err
 		}
@@ -60,7 +60,7 @@ func GetValueOfSetPath(manifest common.K8sManifest, path string) ([]interface{},
 }
 
 // BuildValueOfSetPath build the complete form the `--set` format path and its value
-func BuildValueOfSetPath(val interface{}, path string) (map[string]interface{}, error) {
+func BuildValueOfSetPath(val any, path string) (map[string]any, error) {
 	if path == "" {
 		return nil, fmt.Errorf("set path is empty")
 	}
@@ -90,8 +90,8 @@ type parseTraverser interface {
 }
 
 type buildTraverser struct {
-	data    interface{}
-	cursors []interface{}
+	data    any
+	cursors []any
 }
 
 func (tr *buildTraverser) traverseMapKey(key string) {
@@ -102,24 +102,24 @@ func (tr *buildTraverser) traverseListIdx(idx int) {
 	tr.cursors = append(tr.cursors, idx)
 }
 
-func (tr buildTraverser) getBuildedData() map[string]interface{} {
-	builded := make(map[string]interface{})
-	var current interface{} = builded
+func (tr buildTraverser) getBuildedData() map[string]any {
+	builded := make(map[string]any)
+	var current any = builded
 	for depth, cursor := range tr.cursors {
-		var next interface{}
+		var next any
 		if depth == len(tr.cursors)-1 {
 			next = tr.data
 		} else {
 			if idx, ok := tr.cursors[depth+1].(int); ok {
-				next = make([]interface{}, idx+1)
+				next = make([]any, idx+1)
 			} else {
-				next = make(map[string]interface{})
+				next = make(map[string]any)
 			}
 		}
 		if key, isString := cursor.(string); isString {
-			current.(map[string]interface{})[key] = next
+			current.(map[string]any)[key] = next
 		} else {
-			current.([]interface{})[cursor.(int)] = next
+			current.([]any)[cursor.(int)] = next
 		}
 		current = next
 	}

--- a/pkg/unittest/valueutils/valueutils_test.go
+++ b/pkg/unittest/valueutils/valueutils_test.go
@@ -14,24 +14,24 @@ import (
 func TestGetValueOfSetPathWithSingleResults(t *testing.T) {
 	a := assert.New(t)
 	data := common.K8sManifest{
-		"a": map[string]interface{}{
-			"b":   []interface{}{"_", map[string]interface{}{"c": "yes"}},
+		"a": map[string]any{
+			"b":   []any{"_", map[string]any{"c": "yes"}},
 			"d":   "no",
 			"e.f": "false",
-			"g":   map[string]interface{}{"h": "\"quotes\""},
-			"i":   []interface{}{map[string]interface{}{"i1": "1"}, map[string]interface{}{"i2": "2"}},
+			"g":   map[string]any{"h": "\"quotes\""},
+			"i":   []any{map[string]any{"i1": "1"}, map[string]any{"i2": "2"}},
 		},
 	}
 
-	var expectionsMapping = map[string]interface{}{
+	var expectionsMapping = map[string]any{
 		"a.b[1].c":              "yes",
 		"a.b[0]":                "_",
-		"a.b":                   []interface{}{"_", map[string]interface{}{"c": "yes"}},
+		"a.b":                   []any{"_", map[string]any{"c": "yes"}},
 		"a['d']":                "no",
 		"a[\"e.f\"]":            "false",
 		"a.g.h":                 "\"quotes\"",
 		"":                      data,
-		"a.i[?(@.i1 == \"1\")]": map[string]interface{}(map[string]interface{}{"i1": "1"}),
+		"a.i[?(@.i1 == \"1\")]": map[string]any(map[string]any{"i1": "1"}),
 	}
 
 	for path, expect := range expectionsMapping {
@@ -44,8 +44,8 @@ func TestGetValueOfSetPathWithSingleResults(t *testing.T) {
 func TestGetValueOfSetPathError(t *testing.T) {
 	a := assert.New(t)
 	data := common.K8sManifest{
-		"a": map[string]interface{}{
-			"b":   []interface{}{"_"},
+		"a": map[string]any{
+			"b":   []any{"_"},
 			"c.d": "no",
 		},
 	}
@@ -65,12 +65,12 @@ func TestGetValueOfSetPathError(t *testing.T) {
 
 func TestBuildValueOfSetPath(t *testing.T) {
 	a := assert.New(t)
-	data := map[string]interface{}{"foo": "bar"}
+	data := map[string]any{"foo": "bar"}
 
-	var expectionsMapping = map[string]interface{}{
-		"a.b":    map[string]interface{}{"a": map[string]interface{}{"b": data}},
-		"a[1]":   map[string]interface{}{"a": []interface{}{nil, data}},
-		"a[1].b": map[string]interface{}{"a": []interface{}{nil, map[string]interface{}{"b": data}}},
+	var expectionsMapping = map[string]any{
+		"a.b":    map[string]any{"a": map[string]any{"b": data}},
+		"a[1]":   map[string]any{"a": []any{nil, data}},
+		"a[1].b": map[string]any{"a": []any{nil, map[string]any{"b": data}}},
 	}
 
 	for path, expected := range expectionsMapping {
@@ -91,24 +91,24 @@ func TestBuildValueOfSetPath_V1(t *testing.T) {
 	t.Run("value is empty", func(t *testing.T) {
 		actual, err := BuildValueOfSetPath(nil, "some.path")
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]interface{}{
-			"some": map[string]interface{}{
+		assert.Equal(t, map[string]any{
+			"some": map[string]any{
 				"path": nil,
 			},
 		}, actual)
 	})
 
 	t.Run("some path", func(t *testing.T) {
-		expected := map[string]interface{}{
-			"b": map[string]interface{}{
-				"c": map[string]interface{}{
+		expected := map[string]any{
+			"b": map[string]any{
+				"c": map[string]any{
 					"a": 1,
-					"b": map[string]interface{}{
+					"b": map[string]any{
 						"c": 2,
 					}}}}
-		val := map[string]interface{}{
+		val := map[string]any{
 			"a": 1,
-			"b": map[string]interface{}{
+			"b": map[string]any{
 				"c": 2,
 			},
 		}
@@ -119,17 +119,17 @@ func TestBuildValueOfSetPath_V1(t *testing.T) {
 	})
 
 	t.Run("path is not in data", func(t *testing.T) {
-		expected := map[string]interface{}{
-			"some": map[string]interface{}{
-				"path": map[string]interface{}{
-					"ingress": map[string]interface{}{
+		expected := map[string]any{
+			"some": map[string]any{
+				"path": map[string]any{
+					"ingress": map[string]any{
 						"hosts[1]": "example.local",
 					},
 				},
 			},
 		}
-		var data = map[string]interface{}{
-			"ingress": map[string]interface{}{"hosts[1]": "example.local"},
+		var data = map[string]any{
+			"ingress": map[string]any{"hosts[1]": "example.local"},
 		}
 		actual, err := BuildValueOfSetPath(data, "some.path")
 		assert.NoError(t, err)
@@ -137,15 +137,15 @@ func TestBuildValueOfSetPath_V1(t *testing.T) {
 	})
 
 	t.Run("path is in values", func(t *testing.T) {
-		expected := map[string]interface{}{
-			"hosts": map[string]interface{}{
-				"ingress": map[string]interface{}{
+		expected := map[string]any{
+			"hosts": map[string]any{
+				"ingress": map[string]any{
 					"hosts[1]": "example.local",
 				},
 			},
 		}
-		var data = map[string]interface{}{
-			"ingress": map[string]interface{}{"hosts[1]": "example.local"},
+		var data = map[string]any{
+			"ingress": map[string]any{"hosts[1]": "example.local"},
 		}
 		actual, err := BuildValueOfSetPath(data, "hosts")
 		assert.NoError(t, err)
@@ -153,29 +153,29 @@ func TestBuildValueOfSetPath_V1(t *testing.T) {
 	})
 
 	t.Run("property testing", func(t *testing.T) {
-		data := map[string]interface{}{"foo": "bar"}
+		data := map[string]any{"foo": "bar"}
 		cases := []struct {
-			input  map[string]interface{}
+			input  map[string]any
 			path   string
-			exp    map[string]interface{}
+			exp    map[string]any
 			expStr string
 		}{
 			{
 				path:   "a.b",
-				input:  map[string]interface{}{"a": map[string]interface{}{"b": data}},
-				exp:    map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"a": map[string]interface{}{"b": data}}}},
+				input:  map[string]any{"a": map[string]any{"b": data}},
+				exp:    map[string]any{"a": map[string]any{"b": map[string]any{"a": map[string]any{"b": data}}}},
 				expStr: "map[a:map[b:map[a:map[b:map[foo:bar]]]]]",
 			},
 			{
 				path:   "a[1]",
-				input:  map[string]interface{}{"a": []interface{}{nil, data}},
-				exp:    map[string]interface{}{"a": []interface{}{interface{}(nil), map[string]interface{}{"a": []interface{}{interface{}(nil), data}}}},
+				input:  map[string]any{"a": []any{nil, data}},
+				exp:    map[string]any{"a": []any{any(nil), map[string]any{"a": []any{any(nil), data}}}},
 				expStr: "map[a:[<nil> map[a:[<nil> map[foo:bar]]]]]",
 			},
 			{
 				path:   "a[1].b",
-				input:  map[string]interface{}{"a": []interface{}{nil, map[string]interface{}{"b": data}}},
-				exp:    map[string]interface{}{"a": []interface{}{interface{}(nil), map[string]interface{}{"b": map[string]interface{}{"a": []interface{}{interface{}(nil), map[string]interface{}{"b": data}}}}}},
+				input:  map[string]any{"a": []any{nil, map[string]any{"b": data}}},
+				exp:    map[string]any{"a": []any{any(nil), map[string]any{"b": map[string]any{"a": []any{any(nil), map[string]any{"b": data}}}}}},
 				expStr: "map[a:[<nil> map[b:map[a:[<nil> map[b:map[foo:bar]]]]]]]",
 			},
 		}
@@ -192,7 +192,7 @@ func TestBuildValueOfSetPath_V1(t *testing.T) {
 
 func TestBuildValueSetPathError(t *testing.T) {
 	a := assert.New(t)
-	data := map[string]interface{}{"foo": "bar"}
+	data := map[string]any{"foo": "bar"}
 
 	var expectionsMapping = map[string]string{
 		"":         "set path is empty",
@@ -213,22 +213,22 @@ func TestBuildValueSetPathError(t *testing.T) {
 
 func TestMergeValues(t *testing.T) {
 	a := assert.New(t)
-	src := map[string]interface{}{
-		"a": map[string]interface{}{
-			"b":   []interface{}{"_", map[string]interface{}{"c": "yes"}},
+	src := map[string]any{
+		"a": map[string]any{
+			"b":   []any{"_", map[string]any{"c": "yes"}},
 			"e.f": "false",
 		},
 	}
-	dest := map[string]interface{}{
-		"a": map[string]interface{}{
-			"b":   []interface{}{"_", map[string]interface{}{"c": "no"}, "a"},
+	dest := map[string]any{
+		"a": map[string]any{
+			"b":   []any{"_", map[string]any{"c": "no"}, "a"},
 			"d":   "no",
 			"e.f": "yes",
 		},
 	}
-	expected := map[string]interface{}{
-		"a": map[string]interface{}{
-			"b":   []interface{}{"_", map[string]interface{}{"c": "no"}, "a"},
+	expected := map[string]any{
+		"a": map[string]any{
+			"b":   []any{"_", map[string]any{"c": "no"}, "a"},
 			"d":   "no",
 			"e.f": "yes",
 		},
@@ -240,54 +240,54 @@ func TestMergeValues(t *testing.T) {
 func TestMergeValues_Cases(t *testing.T) {
 
 	t.Run("SimpleMerge", func(t *testing.T) {
-		src := map[string]interface{}{"a": 1, "b": 2}
-		dest := map[string]interface{}{"c": 3, "d": 4}
-		expected := map[string]interface{}{"a": 1, "b": 2, "c": 3, "d": 4}
+		src := map[string]any{"a": 1, "b": 2}
+		dest := map[string]any{"c": 3, "d": 4}
+		expected := map[string]any{"a": 1, "b": 2, "c": 3, "d": 4}
 		result := v3util.MergeTables(dest, src)
 		assert.Equal(t, expected, result)
 	})
 
 	t.Run("OverwriteExistingValue", func(t *testing.T) {
-		src := map[string]interface{}{"a": 1}
-		dest := map[string]interface{}{"a": 2}
-		expected := map[string]interface{}{"a": 2}
+		src := map[string]any{"a": 1}
+		dest := map[string]any{"a": 2}
+		expected := map[string]any{"a": 2}
 		result := v3util.MergeTables(dest, src)
 		assert.Equal(t, expected, result)
 	})
 
 	t.Run("MergeNestedMaps", func(t *testing.T) {
-		src := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
-		dest := map[string]interface{}{"a": map[string]interface{}{"c": 2}}
-		expected := map[string]interface{}{"a": map[string]interface{}{"b": 1, "c": 2}}
+		src := map[string]any{"a": map[string]any{"b": 1}}
+		dest := map[string]any{"a": map[string]any{"c": 2}}
+		expected := map[string]any{"a": map[string]any{"b": 1, "c": 2}}
 		result := v3util.MergeTables(dest, src)
 		assert.Equal(t, expected, result)
 	})
 
 	t.Run("OverwriteNestedMap", func(t *testing.T) {
-		src := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
-		dest := map[string]interface{}{"a": 2}
-		expected := map[string]interface{}{"a": 2}
+		src := map[string]any{"a": map[string]any{"b": 1}}
+		dest := map[string]any{"a": 2}
+		expected := map[string]any{"a": 2}
 		result := v3util.MergeTables(dest, src)
 		assert.Equal(t, expected, result)
 	})
 
 	t.Run("MergeComplexMaps", func(t *testing.T) {
-		src := map[string]interface{}{
+		src := map[string]any{
 			"a": 1,
-			"b": map[string]interface{}{
+			"b": map[string]any{
 				"c": 2,
 			},
 		}
-		dest := map[string]interface{}{
+		dest := map[string]any{
 			"a": 3,
-			"b": map[string]interface{}{
+			"b": map[string]any{
 				"d": 4,
 			},
 			"e": 5,
 		}
-		expected := map[string]interface{}{
+		expected := map[string]any{
 			"a": 3,
-			"b": map[string]interface{}{
+			"b": map[string]any{
 				"c": 2,
 				"d": 4,
 			},
@@ -315,9 +315,9 @@ a:
    foo: bar
   hosts[0]: abrakadabra
 `
-		var dataSrc map[string]interface{}
+		var dataSrc map[string]any
 		common.YmlUnmarshalTestHelper(yamlSrc, &dataSrc, t)
-		var dataDst map[string]interface{}
+		var dataDst map[string]any
 		common.YmlUnmarshalTestHelper(yamlDst, &dataDst, t)
 
 		output := v3util.MergeTables(dataDst, dataSrc)
@@ -346,9 +346,9 @@ a:
    - bar
    hosts[0]: abrakadabra
 `
-		var dataSrc map[string]interface{}
+		var dataSrc map[string]any
 		common.YmlUnmarshalTestHelper(yamlSrc, &dataSrc, t)
-		var dataDst map[string]interface{}
+		var dataDst map[string]any
 		common.YmlUnmarshalTestHelper(yamlDst, &dataDst, t)
 
 		output := v3util.MergeTables(dataDst, dataSrc)
@@ -364,7 +364,7 @@ kind: Deployment
 metadata:
   name: my-deployment
 `
-		var dataDst map[string]interface{}
+		var dataDst map[string]any
 		common.YmlUnmarshalTestHelper(yml, &dataDst, t)
 
 		actual, err := GetValueOfSetPath(dataDst, "invalid.path")
@@ -378,12 +378,12 @@ kind: Deployment
 metadata:
   name: my-deployment
 `
-		var dataDst map[string]interface{}
+		var dataDst map[string]any
 		common.YmlUnmarshalTestHelper(yml, &dataDst, t)
 
 		actual, err := GetValueOfSetPath(dataDst, "metadata.name")
 		assert.NoError(t, err)
-		assert.Equal(t, []interface{}{"my-deployment"}, actual)
+		assert.Equal(t, []any{"my-deployment"}, actual)
 	})
 }
 
@@ -394,32 +394,32 @@ func TestBuildValueOfSetPath_EmptyPath(t *testing.T) {
 }
 
 func TestBuildValueOfSetPath_ValidPath(t *testing.T) {
-	data := map[string]interface{}{"foo": "bar"}
-	expected := map[string]interface{}{"a": map[string]interface{}{"b": data}}
+	data := map[string]any{"foo": "bar"}
+	expected := map[string]any{"a": map[string]any{"b": data}}
 	actual, err := BuildValueOfSetPath(data, "a.b")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
 
 func TestBuildValueOfSetPath_InvalidToken(t *testing.T) {
-	data := map[string]interface{}{"foo": "bar"}
+	data := map[string]any{"foo": "bar"}
 	_, err := BuildValueOfSetPath(data, "{")
 	assert.Error(t, err)
 	assert.EqualError(t, err, "invalid token found {")
 }
 
 func TestBuildValueOfSetPath_UnexpectedEnd(t *testing.T) {
-	data := map[string]interface{}{"foo": "bar"}
+	data := map[string]any{"foo": "bar"}
 	_, err := BuildValueOfSetPath(data, "a[")
 	assert.Error(t, err)
 	assert.EqualError(t, err, "unexpected end of")
 }
 
 func TestBuildValueOfSetPath_NestedPath(t *testing.T) {
-	data := map[string]interface{}{"foo": "bar"}
-	expected := map[string]interface{}{
-		"a": map[string]interface{}{
-			"b": map[string]interface{}{
+	data := map[string]any{"foo": "bar"}
+	expected := map[string]any{
+		"a": map[string]any{
+			"b": map[string]any{
 				"c": data,
 			},
 		},
@@ -431,70 +431,70 @@ func TestBuildValueOfSetPath_NestedPath(t *testing.T) {
 
 // merge values
 func TestMergeValues_EmptySource(t *testing.T) {
-	src := map[string]interface{}{"a": 1}
-	dest := map[string]interface{}{}
-	expected := map[string]interface{}{"a": 1}
+	src := map[string]any{"a": 1}
+	dest := map[string]any{}
+	expected := map[string]any{"a": 1}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_EmptyDestination(t *testing.T) {
-	src := map[string]interface{}{}
-	dest := map[string]interface{}{"a": 1}
-	expected := map[string]interface{}{"a": 1}
+	src := map[string]any{}
+	dest := map[string]any{"a": 1}
+	expected := map[string]any{"a": 1}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_NilDestination(t *testing.T) {
-	src := map[string]interface{}{"a": 1}
-	dest := map[string]interface{}{}
-	expected := map[string]interface{}{"a": 1}
+	src := map[string]any{"a": 1}
+	dest := map[string]any{}
+	expected := map[string]any{"a": 1}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_NilSource(t *testing.T) {
-	src := map[string]interface{}{}
-	dest := map[string]interface{}{"a": 1}
-	expected := map[string]interface{}{"a": 1}
+	src := map[string]any{}
+	dest := map[string]any{"a": 1}
+	expected := map[string]any{"a": 1}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_OverwriteWithNonMap(t *testing.T) {
-	src := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
-	dest := map[string]interface{}{"a": 2}
-	expected := map[string]interface{}{"a": 2}
+	src := map[string]any{"a": map[string]any{"b": 1}}
+	dest := map[string]any{"a": 2}
+	expected := map[string]any{"a": 2}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_DeepMerge(t *testing.T) {
-	src := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
-	dest := map[string]interface{}{"a": map[string]interface{}{"c": 2}}
-	expected := map[string]interface{}{"a": map[string]interface{}{"b": 1, "c": 2}}
+	src := map[string]any{"a": map[string]any{"b": 1}}
+	dest := map[string]any{"a": map[string]any{"c": 2}}
+	expected := map[string]any{"a": map[string]any{"b": 1, "c": 2}}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_ComplexMerge(t *testing.T) {
-	src := map[string]interface{}{
+	src := map[string]any{
 		"a": 1,
-		"b": map[string]interface{}{
+		"b": map[string]any{
 			"c": 2,
 		},
 	}
-	dest := map[string]interface{}{
+	dest := map[string]any{
 		"a": 3,
-		"b": map[string]interface{}{
+		"b": map[string]any{
 			"d": 4,
 		},
 		"e": 5,
 	}
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"a": 3,
-		"b": map[string]interface{}{
+		"b": map[string]any{
 			"c": 2,
 			"d": 4,
 		},
@@ -506,77 +506,77 @@ func TestMergeValues_ComplexMerge(t *testing.T) {
 
 // new
 func TestMergeValues_KeyExistsButNotMap(t *testing.T) {
-	src := map[string]interface{}{
+	src := map[string]any{
 		"a": 1,
 	}
-	dest := map[string]interface{}{
-		"a": map[string]interface{}{"b": 2},
+	dest := map[string]any{
+		"a": map[string]any{"b": 2},
 	}
-	expected := map[string]interface{}{
-		"a": map[string]interface{}{"b": 2},
+	expected := map[string]any{
+		"a": map[string]any{"b": 2},
 	}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_KeyExistsAndIsMap(t *testing.T) {
-	src := map[string]interface{}{
-		"a": map[string]interface{}{"b": 1},
+	src := map[string]any{
+		"a": map[string]any{"b": 1},
 	}
-	dest := map[string]interface{}{
-		"a": map[string]interface{}{"c": 2},
+	dest := map[string]any{
+		"a": map[string]any{"c": 2},
 	}
-	expected := map[string]interface{}{
-		"a": map[string]interface{}{"b": 1, "c": 2},
+	expected := map[string]any{
+		"a": map[string]any{"b": 1, "c": 2},
 	}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_EmptySourceAndDestination(t *testing.T) {
-	src := map[string]interface{}{}
-	dest := map[string]interface{}{}
-	expected := map[string]interface{}{}
+	src := map[string]any{}
+	dest := map[string]any{}
+	expected := map[string]any{}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_DestinationWithNilValue(t *testing.T) {
-	src := map[string]interface{}{"a": 1}
-	dest := map[string]interface{}{"b": nil}
-	expected := map[string]interface{}{"a": 1, "b": nil}
+	src := map[string]any{"a": 1}
+	dest := map[string]any{"b": nil}
+	expected := map[string]any{"a": 1, "b": nil}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_SourceWithNilValue(t *testing.T) {
-	src := map[string]interface{}{"a": nil}
-	dest := map[string]interface{}{"b": 2}
-	expected := map[string]interface{}{"a": nil, "b": 2}
+	src := map[string]any{"a": nil}
+	dest := map[string]any{"b": 2}
+	expected := map[string]any{"a": nil, "b": 2}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_NestedMapWithEmptyMap(t *testing.T) {
-	src := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
-	dest := map[string]interface{}{"a": map[string]interface{}{}}
-	expected := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
+	src := map[string]any{"a": map[string]any{"b": 1}}
+	dest := map[string]any{"a": map[string]any{}}
+	expected := map[string]any{"a": map[string]any{"b": 1}}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_EmptyNestedMap(t *testing.T) {
-	src := map[string]interface{}{"a": map[string]interface{}{}}
-	dest := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
-	expected := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
+	src := map[string]any{"a": map[string]any{}}
+	dest := map[string]any{"a": map[string]any{"b": 1}}
+	expected := map[string]any{"a": map[string]any{"b": 1}}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeValues_OverwriteWithEmptyMap(t *testing.T) {
-	src := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
-	dest := map[string]interface{}{"a": map[string]interface{}{"b": nil}}
-	expected := map[string]interface{}{"a": map[string]interface{}{"b": nil}}
+	src := map[string]any{"a": map[string]any{"b": 1}}
+	dest := map[string]any{"a": map[string]any{"b": nil}}
+	expected := map[string]any{"a": map[string]any{"b": nil}}
 	// expected := map[string]interface{}{"a": map[string]interface{}{}}
 	// this is the expected result when v3util.CoalesceTables is used
 	actual := v3util.MergeTables(dest, src)
@@ -584,9 +584,9 @@ func TestMergeValues_OverwriteWithEmptyMap(t *testing.T) {
 }
 
 func TestMergeValues_OverwriteWithNil(t *testing.T) {
-	src := map[string]interface{}{"a": map[string]interface{}{"b": 1}}
-	dest := map[string]interface{}{"a": nil}
-	expected := map[string]interface{}{"a": nil}
+	src := map[string]any{"a": map[string]any{"b": 1}}
+	dest := map[string]any{"a": nil}
+	expected := map[string]any{"a": nil}
 	actual := v3util.MergeTables(dest, src)
 	assert.Equal(t, expected, actual)
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=helm-unittest
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=helm-unittest
-sonar.projectVersion=0.8.2
+sonar.projectVersion=1.0.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # Define all sources and exclude test-, and vendor files.


### PR DESCRIPTION
Following changes are applied to the code:
- efaceany: replace interface{} by the 'any' type added in go1.18.
- mapsloop: replace a loop around an m[k]=v map update by a call to one of the Collect, Copy, Clone, or Insert functions from the maps package, added in go1.21.
- forvar: remove x := x variable declarations made unnecessary by the new semantics of loops in go1.22.
- rangeint: replace a 3-clause "for i := 0; i < n; i++" loop by "for i := range n", added in go1.22.