### PR TITLE
FailedTemplateWithNotes

### DIFF
--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
@@ -28,7 +28,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 15 passed, 3 skipped, 18 total
-Tests:       45 passed, 4 skipped, 49 total
+Tests:       46 passed, 4 skipped, 50 total
 Snapshot:    5 passed, 5 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
@@ -28,7 +28,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 15 passed, 3 skipped, 18 total
-Tests:       45 passed, 4 skipped, 49 total
+Tests:       46 passed, 4 skipped, 50 total
 Snapshot:    5 passed, 5 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithPassedTests
@@ -28,7 +28,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 15 passed, 3 skipped, 18 total
-Tests:       45 passed, 4 skipped, 49 total
+Tests:       46 passed, 4 skipped, 50 total
 Snapshot:    5 passed, 5 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -583,7 +583,7 @@ func (t *TestJob) parseManifestsFromOutputOfFiles(outputOfFiles map[string]strin
 
 		if !renderSucceed {
 			// RenderSucceed is false, the manifest is already yaml parsed.
-			// se we ensure the extension is .yaml
+			// so we ensure the extension is .yaml
 			fileExtension = ".yaml"
 		}
 

--- a/test/data/v3/basic/templates/NOTES.txt
+++ b/test/data/v3/basic/templates/NOTES.txt
@@ -1,3 +1,6 @@
+{{ if and (hasKey $.Values "__test") (($__test := index $.Values "__test") | empty | not) -}}
+{{ tpl $__test $ -}}
+{{ else -}}
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
@@ -17,3 +20,4 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
 {{- end }}
+{{ end -}}

--- a/test/data/v3/basic/tests/notes_test.yaml
+++ b/test/data/v3/basic/tests/notes_test.yaml
@@ -32,3 +32,11 @@ tests:
       - matchRegexRaw:
           pattern: http://\$SERVICE_IP:9999
       - matchSnapshotRaw: {}
+
+  - it: should fail the notes file when __test is set
+    set:
+      __test: |
+        {{ fail "some: error text" }}
+    asserts:
+      - failedTemplate:
+          errorMessage: "some: error text"


### PR DESCRIPTION
**Solution**
Make parsing output files aware when a render failure has occurred, including (updated) test validations. (resolves #652, #183)

**Rootcause**
During render failures the error will be wrapped in a yaml structure with raw as root node, similar as parsing output files does when txt files are found. The fix is to avoid duplication of the yaml structuring.

**Additional information**
The reason to wrap errors and .txt files in a predefined yaml structure is to make the assertions reusable.

