### PR TITLE
Bugfix/correct new yaml newlines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: publish artifacts
       # https://github.com/softprops/action-gh-release
-      uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
+      uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7 # v2.3.4
       with:
         files: _dist/**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 1.0.3 / 2025-04-10
 ==================
-- Corrected newlines which is handled inccorrectly by the yaml library (resolves #756) 
+- Corrected newlines which is handled incorrectly by the yaml library (resolves #756) 
 - Update packages to latest patch versions
 - Update pipeline actions
 - Update documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.0.3 / 2025-04-10
+==================
+- Corrected newlines which is handled inccorrectly by the yaml library (resolves #756) 
+- Update packages to latest patch versions
+- Update pipeline actions
+- Update documentation
+
 1.0.2 / 2025-01-10
 ==================
 - Replaced yaml library with a maintained alternative (resolves #501) 

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -1,7 +1,7 @@
 package common
 
 // K8sManifest type for rendered manifest unmarshalled to
-type K8sManifest map[string]any
+type K8sManifest = map[string]any
 
 // RAW the key value for making content parsable as K8sManifest
 const RAW string = "raw"

--- a/internal/common/utilities.go
+++ b/internal/common/utilities.go
@@ -118,11 +118,11 @@ func removeLeadingNewLines(v any) any {
 	switch val := v.(type) {
 	case string:
 		return strings.TrimLeft(val, "\n")
-	case K8sManifest:
+	case map[string]any:
 		if val == nil {
 			return val
 		}
-		result := make(K8sManifest)
+		result := make(map[string]any)
 		for k, v := range val {
 			result[k] = removeLeadingNewLines(v)
 		}

--- a/internal/common/utilities_test.go
+++ b/internal/common/utilities_test.go
@@ -185,7 +185,7 @@ func TestTrustedMarshalYAML(t *testing.T) {
 			name: "string with leading newline (block scalar normalization)",
 			input: map[string]any{
 				"data": map[string]any{
-					"content": "{}\n",
+					"content": "\n{}\n",
 				},
 			},
 			// The normalized output should NOT have a blank line after |
@@ -197,7 +197,7 @@ func TestTrustedMarshalYAML(t *testing.T) {
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
 				"data": map[string]any{
-					"overrides.json": "{}\n",
+					"overrides.json": "\n\n{}\n",
 				},
 			},
 			// Should not have blank line after |

--- a/internal/common/utilities_test.go
+++ b/internal/common/utilities_test.go
@@ -160,27 +160,27 @@ func TestTrustedMarshalYAML(t *testing.T) {
 		expected    string
 		expectError bool
 	}{
-		// {
-		// 	name:     "simple map",
-		// 	input:    map[string]any{"name": "test", "version": "1.0"},
-		// 	expected: "name: test\nversion: \"1.0\"\n",
-		// },
-		// {
-		// 	name:     "nested map",
-		// 	input:    map[string]any{"metadata": map[string]any{"name": "test"}},
-		// 	expected: "metadata:\n  name: test\n",
-		// },
-		// {
-		// 	name:     "nil input",
-		// 	input:    nil,
-		// 	expected: "null\n",
-		// },
-		// {
-		// 	name:        "invalid yaml",
-		// 	input:       func() {}, // functions cannot be marshaled to YAML
-		// 	expected:    "invalid",
-		// 	expectError: true,
-		// },
+		{
+			name:     "simple map",
+			input:    map[string]any{"name": "test", "version": "1.0"},
+			expected: "name: test\nversion: \"1.0\"\n",
+		},
+		{
+			name:     "nested map",
+			input:    map[string]any{"metadata": map[string]any{"name": "test"}},
+			expected: "metadata:\n  name: test\n",
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: "null\n",
+		},
+		{
+			name:        "invalid yaml",
+			input:       func() {}, // functions cannot be marshaled to YAML
+			expected:    "invalid",
+			expectError: true,
+		},
 		{
 			name: "string with leading newline (block scalar normalization)",
 			input: map[string]any{

--- a/internal/common/utilities_test.go
+++ b/internal/common/utilities_test.go
@@ -156,6 +156,28 @@ func TestTrustedMarshalYAML(t *testing.T) {
 			expected:    "invalid",
 			expectError: true,
 		},
+		{
+			name: "string with leading newline (block scalar normalization)",
+			input: map[string]any{
+				"data": map[string]any{
+					"content": "\n    {}",
+				},
+			},
+			// The normalized output should NOT have a blank line after |2-
+			expected: "data:\n  content: |2-\n        {}\n",
+		},
+		{
+			name: "configmap with toJson nindent pattern",
+			input: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"data": map[string]any{
+					"overrides.json": "\n    {}",
+				},
+			},
+			// Should not have blank line after |2-
+			expected: "apiVersion: v1\ndata:\n  overrides.json: |2-\n        {}\nkind: ConfigMap\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/common/utilities_test.go
+++ b/internal/common/utilities_test.go
@@ -102,6 +102,31 @@ func TestTrustedUnmarshalYml(t *testing.T) {
 			},
 		},
 		{
+			name: "valid yaml to map",
+			input: `
+---
+# Source: full-snapshot/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-overrides
+data:
+  overrides.json: |
+
+    {}
+`,
+			expected: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name": "release-name-overrides",
+				},
+				"data": map[string]any{
+					"overrides.json": "\n{}\n",
+				},
+			},
+		},
+		{
 			name:        "empty yaml",
 			input:       "",
 			expectError: true,
@@ -135,36 +160,36 @@ func TestTrustedMarshalYAML(t *testing.T) {
 		expected    string
 		expectError bool
 	}{
-		{
-			name:     "simple map",
-			input:    map[string]any{"name": "test", "version": "1.0"},
-			expected: "name: test\nversion: \"1.0\"\n",
-		},
-		{
-			name:     "nested map",
-			input:    map[string]any{"metadata": map[string]any{"name": "test"}},
-			expected: "metadata:\n  name: test\n",
-		},
-		{
-			name:     "nil input",
-			input:    nil,
-			expected: "null\n",
-		},
-		{
-			name:        "invalid yaml",
-			input:       func() {}, // functions cannot be marshaled to YAML
-			expected:    "invalid",
-			expectError: true,
-		},
+		// {
+		// 	name:     "simple map",
+		// 	input:    map[string]any{"name": "test", "version": "1.0"},
+		// 	expected: "name: test\nversion: \"1.0\"\n",
+		// },
+		// {
+		// 	name:     "nested map",
+		// 	input:    map[string]any{"metadata": map[string]any{"name": "test"}},
+		// 	expected: "metadata:\n  name: test\n",
+		// },
+		// {
+		// 	name:     "nil input",
+		// 	input:    nil,
+		// 	expected: "null\n",
+		// },
+		// {
+		// 	name:        "invalid yaml",
+		// 	input:       func() {}, // functions cannot be marshaled to YAML
+		// 	expected:    "invalid",
+		// 	expectError: true,
+		// },
 		{
 			name: "string with leading newline (block scalar normalization)",
 			input: map[string]any{
 				"data": map[string]any{
-					"content": "\n    {}",
+					"content": "{}\n",
 				},
 			},
-			// The normalized output should NOT have a blank line after |2-
-			expected: "data:\n  content: |2-\n        {}\n",
+			// The normalized output should NOT have a blank line after |
+			expected: "data:\n  content: |\n    {}\n",
 		},
 		{
 			name: "configmap with toJson nindent pattern",
@@ -172,11 +197,11 @@ func TestTrustedMarshalYAML(t *testing.T) {
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
 				"data": map[string]any{
-					"overrides.json": "\n    {}",
+					"overrides.json": "{}\n",
 				},
 			},
-			// Should not have blank line after |2-
-			expected: "apiVersion: v1\ndata:\n  overrides.json: |2-\n        {}\nkind: ConfigMap\n",
+			// Should not have blank line after |
+			expected: "apiVersion: v1\ndata:\n  overrides.json: |\n    {}\nkind: ConfigMap\n",
 		},
 	}
 

--- a/internal/common/utilities_test.go
+++ b/internal/common/utilities_test.go
@@ -203,6 +203,24 @@ func TestTrustedMarshalYAML(t *testing.T) {
 			// Should not have blank line after |
 			expected: "apiVersion: v1\ndata:\n  overrides.json: |\n    {}\nkind: ConfigMap\n",
 		},
+		{
+			name: "configmap with array toJson nindent pattern",
+			input: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"data": []any{
+					map[string]any{
+						"overrides1.json": "\n{}\n",
+					},
+					map[string]any{
+						"overrides2.json": "\n{}\n",
+					},
+				},
+			},
+
+			// Should not have blank line after |
+			expected: "apiVersion: v1\ndata:\n  - overrides1.json: |\n      {}\n  - overrides2.json: |\n      {}\nkind: ConfigMap\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
@@ -28,7 +28,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 15 passed, 3 skipped, 18 total
-Tests:       46 passed, 4 skipped, 50 total
+Tests:       47 passed, 4 skipped, 51 total
 Snapshot:    5 passed, 5 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithFullsnapshot
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithFullsnapshot
@@ -7,8 +7,8 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshot:    14 passed, 14 total
+Tests:       3 passed, 3 total
+Snapshot:    17 passed, 17 total
 Time:        XX.XXXms
 
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
@@ -28,7 +28,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 15 passed, 3 skipped, 18 total
-Tests:       46 passed, 4 skipped, 50 total
+Tests:       47 passed, 4 skipped, 51 total
 Snapshot:    5 passed, 5 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithPassedTests
@@ -28,7 +28,7 @@
 
 Charts:      1 passed, 1 total
 Test Suites: 15 passed, 3 skipped, 18 total
-Tests:       46 passed, 4 skipped, 50 total
+Tests:       47 passed, 4 skipped, 51 total
 Snapshot:    5 passed, 5 total
 Time:        XX.XXXms
 

--- a/pkg/unittest/validators/common.go
+++ b/pkg/unittest/validators/common.go
@@ -125,7 +125,7 @@ func diff(expected string, actual string) string {
 // uniform the content without invalid characters and correct line-endings
 func uniformContent(content any) string {
 	actual := fmt.Sprintf("%v", content)
-	return regex.ReplaceAllString(actual, "\n")
+	return strings.TrimLeft(regex.ReplaceAllString(actual, "\n"), "\n")
 }
 
 // Validate a subset, which are used for SubsetValidator and Contains (when Any option is used)

--- a/plugin-dbg.yaml
+++ b/plugin-dbg.yaml
@@ -1,5 +1,5 @@
 name: "unittest"
-version: "1.0.2"
+version: "1.0.3"
 usage: "unittest for helm charts"
 description: "Unit test for helm chart in YAML with ease to keep your chart functional and robust."
 ignoreFlags: false

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "unittest"
-version: "1.0.2"
+version: "1.0.3"
 usage: "unittest for helm charts"
 description: "Unit test for helm chart in YAML with ease to keep your chart functional and robust."
 ignoreFlags: false

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=helm-unittest
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=helm-unittest
-sonar.projectVersion=1.0.2
+sonar.projectVersion=1.0.3
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # Define all sources and exclude test-, and vendor files.

--- a/test/data/v3/basic/templates/configmap.yaml
+++ b/test/data/v3/basic/templates/configmap.yaml
@@ -28,7 +28,12 @@ data:
   {{- if .Values.ingress.hosts }}
   my.ingress.hosts:
   {{- range $host := .Values.ingress.hosts }}
-  - {{ $host }}
+    - {{ $host }}
   {{- end -}}
   {{- end -}}
-
+  {{- if .Values.configJsonTests }}
+  file.json: |
+  {{ range .Values.configJsonTests | toStrings }}
+    {{ . | nindent 4 }}
+  {{- end }}
+  {{- end }}

--- a/test/data/v3/basic/tests/configmap_test.yaml
+++ b/test/data/v3/basic/tests/configmap_test.yaml
@@ -171,3 +171,20 @@ tests:
             - chart-example-first.local
             - override-example-patch-1.local
             - chart-example-third.local
+
+# issue https://github.com/helm-unittest/helm-unittest/issues/756
+  - it: "should have equal values for json to strings"
+    set:
+      configJsonTests: |-
+        {
+          "key1": "value1"
+        }
+    asserts:
+      - exists:
+          path: data["file.json"]
+      - equal:
+          path: data["file.json"]
+          value: |
+            {
+              "key1": "value1"
+            }

--- a/test/data/v3/full-snapshot/templates/configmap.yaml
+++ b/test/data/v3/full-snapshot/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-overrides
+data:
+  overrides.json: |
+    {{ .Values.overrides | toJson | nindent 4 }}

--- a/test/data/v3/full-snapshot/templates/configmap.yaml
+++ b/test/data/v3/full-snapshot/templates/configmap.yaml
@@ -3,5 +3,5 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-overrides
 data:
-  overrides.json: |
+  overrides.json: | 
     {{ .Values.overrides | toJson | nindent 4 }}

--- a/test/data/v3/full-snapshot/tests/__snapshot__/full_snapshot_test.yaml.snap
+++ b/test/data/v3/full-snapshot/tests/__snapshot__/full_snapshot_test.yaml.snap
@@ -1,3 +1,23 @@
+configmap must render successfully with overrides:
+  1: |
+    apiVersion: v1
+    data:
+      overrides.json: |2
+
+        {"globals":{"my_param":["foo","bar"]}}
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME-overrides
+configmap must render with default values:
+  1: |
+    apiVersion: v1
+    data:
+      overrides.json: |2
+
+        {}
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME-overrides
 matches the snapshot:
   1: |
     raw: |
@@ -150,6 +170,15 @@ matches the snapshot:
       1. Get the application URL by running these commands:
         http://chart-example.local/
   9: |
+    apiVersion: v1
+    data:
+      overrides.json: |2
+
+        {}
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME-overrides
+  10: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -191,7 +220,7 @@ matches the snapshot:
               securityContext: {}
           securityContext: {}
           serviceAccountName: RELEASE-NAME-full-snapshot
-  10: |
+  11: |
     apiVersion: autoscaling/v2beta1
     kind: HorizontalPodAutoscaler
     metadata:
@@ -214,7 +243,7 @@ matches the snapshot:
         apiVersion: apps/v1
         kind: Deployment
         name: RELEASE-NAME-full-snapshot
-  11: |
+  12: |
     apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
@@ -237,7 +266,7 @@ matches the snapshot:
                       number: 80
                 path: /
                 pathType: ImplementationSpecific
-  12: |
+  13: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -258,7 +287,7 @@ matches the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: full-snapshot
       type: ClusterIP
-  13: |
+  14: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -269,7 +298,7 @@ matches the snapshot:
         app.kubernetes.io/version: 1.16.0
         helm.sh/chart: full-snapshot-0.1.0
       name: RELEASE-NAME-full-snapshot
-  14: |
+  15: |
     apiVersion: v1
     kind: Pod
     metadata:

--- a/test/data/v3/full-snapshot/tests/__snapshot__/full_snapshot_test.yaml.snap
+++ b/test/data/v3/full-snapshot/tests/__snapshot__/full_snapshot_test.yaml.snap
@@ -3,7 +3,6 @@ configmap must render successfully with overrides:
     apiVersion: v1
     data:
       overrides.json: |2
-
         {"globals":{"my_param":["foo","bar"]}}
     kind: ConfigMap
     metadata:
@@ -13,7 +12,6 @@ configmap must render with default values:
     apiVersion: v1
     data:
       overrides.json: |2
-
         {}
     kind: ConfigMap
     metadata:
@@ -173,7 +171,6 @@ matches the snapshot:
     apiVersion: v1
     data:
       overrides.json: |2
-
         {}
     kind: ConfigMap
     metadata:

--- a/test/data/v3/full-snapshot/tests/__snapshot__/full_snapshot_test.yaml.snap
+++ b/test/data/v3/full-snapshot/tests/__snapshot__/full_snapshot_test.yaml.snap
@@ -2,7 +2,7 @@ configmap must render successfully with overrides:
   1: |
     apiVersion: v1
     data:
-      overrides.json: |2
+      overrides.json: |
         {"globals":{"my_param":["foo","bar"]}}
     kind: ConfigMap
     metadata:
@@ -11,7 +11,7 @@ configmap must render with default values:
   1: |
     apiVersion: v1
     data:
-      overrides.json: |2
+      overrides.json: |
         {}
     kind: ConfigMap
     metadata:
@@ -170,7 +170,7 @@ matches the snapshot:
   9: |
     apiVersion: v1
     data:
-      overrides.json: |2
+      overrides.json: |
         {}
     kind: ConfigMap
     metadata:

--- a/test/data/v3/full-snapshot/tests/full_snapshot_test.yaml
+++ b/test/data/v3/full-snapshot/tests/full_snapshot_test.yaml
@@ -15,3 +15,17 @@ tests:
       ingress.enabled: true
     asserts:
       - matchSnapshot: {}
+  - it: configmap must render with default values
+    templates:
+      - templates/configmap.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: configmap must render successfully with overrides
+    templates:
+      - templates/configmap.yaml
+    set:
+      overrides:
+        globals:
+          my_param: [foo, bar]
+    asserts:
+      - matchSnapshot: {}

--- a/test/data/v3/full-snapshot/values.yaml
+++ b/test/data/v3/full-snapshot/values.yaml
@@ -80,3 +80,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+overrides: {}


### PR DESCRIPTION
This pull request addresses an issue with YAML serialization where leading newlines could appear in block scalar strings, particularly affecting Helm ConfigMap rendering and snapshot testing. The main changes implement a recursive normalization to remove leading newlines from string values during YAML marshaling, add new tests to verify this behavior, and update existing test snapshots to reflect the improved output.

**YAML Serialization and Normalization:**
- Added a new `removeLeadingNewLines` function in `internal/common/utilities.go` that recursively strips leading newlines from all string values in maps and slices, and integrated this into the `TrustedMarshalYAML` function to prevent unwanted blank lines in block scalars.
- Updated `TrustedUnmarshalYAML` to use a `map[string]any{}` instead of a custom type for consistency.
- Adjusted content normalization in `uniformContent` to also trim leading newlines for more accurate diff comparisons in tests.

**Testing Improvements:**
- Added and updated tests in `internal/common/utilities_test.go` to verify correct YAML marshaling and unmarshaling, especially for block scalars and ConfigMap data fields.
- Added new test cases and templates in `test/data/v3/full-snapshot` and `test/data/v3/basic` to ensure correct handling of JSON strings and block scalar formatting in ConfigMaps.

**Snapshot Updates:**
- Updated multiple snapshot files to reflect the improved YAML output, including removal of unnecessary blank lines and correct block scalar formatting. This also increased the number of passing tests and snapshots.

These changes collectively fix the YAML block scalar newline issue (resolves #756), improve test reliability, and ensure more predictable YAML output for consumers.