### PR TITLE
Disable default schema validation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: "0 0 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ env:
   PLUGIN_REPO: helm-unittest/helm-unittest
   GO_VERSION: 1.25.x
 
+permissions: {}
+
 jobs:
   release:
     name: create distribution and upload to release

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,6 +14,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -142,7 +142,7 @@ func InitPluginFlags(cmd *cobra.Command) {
 	)
 
 	cmd.PersistentFlags().BoolVar(
-		&testConfig.useSkipSchemaValidation, "skip-schema-validation", true,
+		&testConfig.useSkipSchemaValidation, "skip-schema-validation", false,
 		"skip schema validation when rendering helmcharts",
 	)
 

--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -15,17 +15,18 @@ import (
 
 // testOptions stores options setup by user in command line
 type testOptions struct {
-	debugLogging   bool
-	useFailfast    bool
-	useStrict      bool
-	colored        bool
-	updateSnapshot bool
-	withSubChart   bool
-	testFiles      []string
-	valuesFiles    []string
-	outputFile     string
-	outputType     string
-	chartTestsPath string
+	debugLogging            bool
+	useFailfast             bool
+	useStrict               bool
+	useSkipSchemaValidation bool
+	colored                 bool
+	updateSnapshot          bool
+	withSubChart            bool
+	testFiles               []string
+	valuesFiles             []string
+	outputFile              string
+	outputType              string
+	chartTestsPath          string
 }
 
 var defaultFilePattern = filepath.Join("tests", "*_test.yaml")
@@ -91,17 +92,18 @@ func RunPlugin(cmd *cobra.Command, chartPaths []string) {
 	formatter := formatter.NewFormatter(testConfig.outputFile, testConfig.outputType)
 	printer := printer.NewPrinter(os.Stdout, colored)
 	testRunner = unittest.TestRunner{
-		Printer:        printer,
-		Formatter:      formatter,
-		UpdateSnapshot: testConfig.updateSnapshot,
-		WithSubChart:   testConfig.withSubChart,
-		Strict:         testConfig.useStrict,
-		Failfast:       testConfig.useFailfast,
-		TestFiles:      testConfig.testFiles,
-		ValuesFiles:    testConfig.valuesFiles,
-		OutputFile:     testConfig.outputFile,
-		ChartTestsPath: testConfig.chartTestsPath,
-		RenderPath:     renderPath,
+		Printer:              printer,
+		Formatter:            formatter,
+		UpdateSnapshot:       testConfig.updateSnapshot,
+		WithSubChart:         testConfig.withSubChart,
+		Strict:               testConfig.useStrict,
+		Failfast:             testConfig.useFailfast,
+		SkipSchemaValidation: testConfig.useSkipSchemaValidation,
+		TestFiles:            testConfig.testFiles,
+		ValuesFiles:          testConfig.valuesFiles,
+		OutputFile:           testConfig.outputFile,
+		ChartTestsPath:       testConfig.chartTestsPath,
+		RenderPath:           renderPath,
 	}
 
 	log.SetFormatter(&log.TextFormatter{
@@ -137,6 +139,11 @@ func InitPluginFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(
 		&testConfig.useStrict, "strict", false,
 		"strict parse the testsuites",
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&testConfig.useSkipSchemaValidation, "skip-schema-validation", true,
+		"skip schema validation when rendering helmcharts",
 	)
 
 	cmd.PersistentFlags().StringArrayVarP(

--- a/cmd/helm-unittest/helm_unittest_test.go
+++ b/cmd/helm-unittest/helm_unittest_test.go
@@ -116,6 +116,32 @@ func TestValidateUnittestStrictFlag(t *testing.T) {
 	}
 }
 
+func TestValidateUnittestSkipSchemaValidationFlag(t *testing.T) {
+	a := assert.New(t)
+
+	skipSchemaValidationFlags := map[string]bool{
+		"":                               true,
+		"--skip-schema-validation":       true,
+		"--skip-schema-validation=false": false,
+		"--skip-schema-validation=true":  true,
+	}
+
+	for skipSchemaValidationFlag, skipSchemaValidationFlagValue := range skipSchemaValidationFlags {
+		cmd := setupTestCmd()
+
+		// Setup actual parameter
+		if len(skipSchemaValidationFlag) > 0 {
+			cmd.SetArgs([]string{skipSchemaValidationFlag})
+		}
+
+		err := cmd.Execute()
+		runner := GetTestRunner()
+
+		a.Nil(err)
+		a.Equal(skipSchemaValidationFlagValue, runner.SkipSchemaValidation)
+	}
+}
+
 func TestValidateUnittestFailFastFlags(t *testing.T) {
 	a := assert.New(t)
 

--- a/cmd/helm-unittest/helm_unittest_test.go
+++ b/cmd/helm-unittest/helm_unittest_test.go
@@ -120,7 +120,7 @@ func TestValidateUnittestSkipSchemaValidationFlag(t *testing.T) {
 	a := assert.New(t)
 
 	skipSchemaValidationFlags := map[string]bool{
-		"":                               true,
+		"":                               false,
 		"--skip-schema-validation":       true,
 		"--skip-schema-validation=false": false,
 		"--skip-schema-validation=true":  true,

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -13,6 +13,7 @@ type TestConfig struct {
 	cache               *snapshot.Cache
 	renderPath          string
 	failFast            bool
+	strict              bool
 	isSkipEmptyTemplate bool
 	postRenderer        PostRendererConfig
 }
@@ -37,6 +38,12 @@ type LoadTestOptionsFunc func(*TestConfig)
 func WithFailFast(failFast bool) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
 		c.failFast = failFast
+	}
+}
+
+func WithStrict(strict bool) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		c.strict = strict
 	}
 }
 

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -9,13 +9,13 @@ import (
 )
 
 type TestConfig struct {
-	targetChart         *v3chart.Chart
-	cache               *snapshot.Cache
-	renderPath          string
-	failFast            bool
-	strict              bool
-	isSkipEmptyTemplate bool
-	postRenderer        PostRendererConfig
+	targetChart          *v3chart.Chart
+	cache                *snapshot.Cache
+	renderPath           string
+	failFast             bool
+	skipSchemaValidation bool
+	isSkipEmptyTemplate  bool
+	postRenderer         PostRendererConfig
 }
 
 func NewTestConfig(chart *v3chart.Chart, cache *snapshot.Cache, options ...func(*TestConfig)) *TestConfig {
@@ -41,9 +41,9 @@ func WithFailFast(failFast bool) LoadTestOptionsFunc {
 	}
 }
 
-func WithStrict(strict bool) LoadTestOptionsFunc {
+func WithSkipSchemaValidation(skipSchemaValidation bool) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
-		c.strict = strict
+		c.skipSchemaValidation = skipSchemaValidation
 	}
 }
 

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -370,7 +370,7 @@ func (t *TestJob) renderV3Chart(userValues []byte) (map[string]string, bool, err
 		return nil, false, err
 	}
 
-	vals, err := v3util.ToRenderValuesWithSchemaValidation(t.configOrDefault().targetChart, values.AsMap(), options, t.capabilitiesV3(), t.configOrDefault().strict)
+	vals, err := v3util.ToRenderValuesWithSchemaValidation(t.configOrDefault().targetChart, values.AsMap(), options, t.capabilitiesV3(), !t.configOrDefault().strict)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -370,7 +370,7 @@ func (t *TestJob) renderV3Chart(userValues []byte) (map[string]string, bool, err
 		return nil, false, err
 	}
 
-	vals, err := v3util.ToRenderValuesWithSchemaValidation(t.configOrDefault().targetChart, values.AsMap(), options, t.capabilitiesV3(), !t.configOrDefault().strict)
+	vals, err := v3util.ToRenderValuesWithSchemaValidation(t.configOrDefault().targetChart, values.AsMap(), options, t.capabilitiesV3(), t.configOrDefault().skipSchemaValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -370,7 +370,7 @@ func (t *TestJob) renderV3Chart(userValues []byte) (map[string]string, bool, err
 		return nil, false, err
 	}
 
-	vals, err := v3util.ToRenderValuesWithSchemaValidation(t.configOrDefault().targetChart, values.AsMap(), options, t.capabilitiesV3(), false)
+	vals, err := v3util.ToRenderValuesWithSchemaValidation(t.configOrDefault().targetChart, values.AsMap(), options, t.capabilitiesV3(), t.configOrDefault().strict)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -70,22 +70,23 @@ type totalSnapshotCounting struct {
 
 // TestRunner stores basic settings and testing status for running all tests
 type TestRunner struct {
-	Printer          *printer.Printer
-	Formatter        formatter.Formatter
-	UpdateSnapshot   bool
-	WithSubChart     bool
-	Strict           bool
-	Failfast         bool
-	TestFiles        []string
-	ChartTestsPath   string
-	ValuesFiles      []string
-	OutputFile       string
-	RenderPath       string
-	suiteCounting    testUnitCountingWithSnapshotFailed
-	testCounting     testUnitCounting
-	chartCounting    testUnitCounting
-	snapshotCounting totalSnapshotCounting
-	testResults      []*results.TestSuiteResult
+	Printer              *printer.Printer
+	Formatter            formatter.Formatter
+	UpdateSnapshot       bool
+	WithSubChart         bool
+	Strict               bool
+	Failfast             bool
+	SkipSchemaValidation bool
+	TestFiles            []string
+	ChartTestsPath       string
+	ValuesFiles          []string
+	OutputFile           string
+	RenderPath           string
+	suiteCounting        testUnitCountingWithSnapshotFailed
+	testCounting         testUnitCounting
+	chartCounting        testUnitCounting
+	snapshotCounting     totalSnapshotCounting
+	testResults          []*results.TestSuiteResult
 }
 
 // RunV3 test suites in chart in ChartPaths.
@@ -220,7 +221,7 @@ func (tr *TestRunner) runV3SuitesOfChart(suites []*TestSuite, chart *v3chart.Cha
 			chartPassed = false
 			continue
 		}
-		result := suite.RunV3(chart, snapshotCache, tr.Failfast, tr.RenderPath, tr.Strict, &results.TestSuiteResult{})
+		result := suite.RunV3(chart, snapshotCache, tr.Failfast, tr.RenderPath, tr.SkipSchemaValidation, &results.TestSuiteResult{})
 		chartPassed = chartPassed && result.Passed
 		tr.handleSuiteResult(result)
 		tr.testResults = append(tr.testResults, result)

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -220,7 +220,7 @@ func (tr *TestRunner) runV3SuitesOfChart(suites []*TestSuite, chart *v3chart.Cha
 			chartPassed = false
 			continue
 		}
-		result := suite.RunV3(chart, snapshotCache, tr.Failfast, tr.RenderPath, &results.TestSuiteResult{})
+		result := suite.RunV3(chart, snapshotCache, tr.Failfast, tr.RenderPath, tr.Strict, &results.TestSuiteResult{})
 		chartPassed = chartPassed && result.Passed
 		tr.handleSuiteResult(result)
 		tr.testResults = append(tr.testResults, result)

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -254,6 +254,7 @@ func (s *TestSuite) RunV3(
 	snapshotCache *snapshot.Cache,
 	failFast bool,
 	renderPath string,
+	strict bool,
 	result *results.TestSuiteResult,
 ) *results.TestSuiteResult {
 	s.polishTestJobsPathInfo()
@@ -266,6 +267,7 @@ func (s *TestSuite) RunV3(
 		snapshotCache,
 		failFast,
 		renderPath,
+		strict,
 	)
 
 	result.Passed = r.Pass
@@ -381,6 +383,7 @@ func (s *TestSuite) runV3TestJobs(
 	cache *snapshot.Cache,
 	failFast bool,
 	renderPath string,
+	strict bool,
 ) *SuiteResult {
 	result := SuiteResult{Pass: false, FailFast: false, Skip: false}
 	jobResults := make([]*results.TestJobResult, len(s.Tests))
@@ -404,6 +407,7 @@ func (s *TestSuite) runV3TestJobs(
 			testJob.WithConfig(*NewTestConfig(chartClone, cache,
 				WithRenderPath(renderPath),
 				WithFailFast(failFast),
+				WithStrict(strict),
 				WithPostRendererConfig(s.PostRendererConfig),
 				WithDocumentSelector(testJob.DocumentSelector),
 			))

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -254,7 +254,7 @@ func (s *TestSuite) RunV3(
 	snapshotCache *snapshot.Cache,
 	failFast bool,
 	renderPath string,
-	strict bool,
+	skipSchemaValidation bool,
 	result *results.TestSuiteResult,
 ) *results.TestSuiteResult {
 	s.polishTestJobsPathInfo()
@@ -267,7 +267,7 @@ func (s *TestSuite) RunV3(
 		snapshotCache,
 		failFast,
 		renderPath,
-		strict,
+		skipSchemaValidation,
 	)
 
 	result.Passed = r.Pass
@@ -383,7 +383,7 @@ func (s *TestSuite) runV3TestJobs(
 	cache *snapshot.Cache,
 	failFast bool,
 	renderPath string,
-	strict bool,
+	skipSchemaValidation bool,
 ) *SuiteResult {
 	result := SuiteResult{Pass: false, FailFast: false, Skip: false}
 	jobResults := make([]*results.TestJobResult, len(s.Tests))
@@ -407,7 +407,7 @@ func (s *TestSuite) runV3TestJobs(
 			testJob.WithConfig(*NewTestConfig(chartClone, cache,
 				WithRenderPath(renderPath),
 				WithFailFast(failFast),
-				WithStrict(strict),
+				WithSkipSchemaValidation(skipSchemaValidation),
 				WithPostRendererConfig(s.PostRendererConfig),
 				WithDocumentSelector(testJob.DocumentSelector),
 			))

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -461,7 +461,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_noasserts_template_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, false, "validate empty asserts", 1, 0, 0, 0, 0)
 }
@@ -502,7 +502,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_multiple_template_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "validate metadata", 1, 5, 5, 0, 0)
 }
@@ -528,7 +528,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_suite_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite name", 1, 2, 2, 0, 0)
 }
@@ -566,7 +566,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_suite_override_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite name", 1, 1, 1, 0, 0)
 }
@@ -591,7 +591,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_failed_suite_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, false, "test suite name", 1, 0, 0, 0, 0)
 }
@@ -616,7 +616,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_subfolder_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite name", 1, 2, 2, 0, 0)
 }
@@ -640,7 +640,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_subchart_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite with subchart", 1, 1, 1, 0, 0)
 }
@@ -665,7 +665,7 @@ tests:
 	chart, chartErr := v3loader.Load(testV3WithSubChart)
 	assert.NoError(t, chartErr)
 
-	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", false, &results.TestSuiteResult{})
 	assert.True(t, suiteResult.Passed)
 }
 
@@ -688,7 +688,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_subchartwithtrimming_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test cert-manager rbac with trimming", 1, 0, 0, 0, 0)
 }
@@ -720,7 +720,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_subchartwithalias_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite with subchart", 2, 2, 2, 0, 0)
 }
@@ -747,7 +747,7 @@ tests:
 	chart, chartErr := v3loader.Load(testV3WithSubChart)
 	assert.NoError(t, chartErr)
 
-	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", false, &results.TestSuiteResult{})
 
 	assert.Empty(t, testSuite.Chart.AppVersion)
 	assert.Empty(t, testSuite.Chart.Version)
@@ -777,7 +777,7 @@ tests:
 	chart, chartErr := v3loader.Load(testV3WithSubChart)
 	assert.NoError(t, chartErr)
 
-	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", false, &results.TestSuiteResult{})
 
 	assert.Empty(t, testSuite.Chart.AppVersion)
 	assert.Equal(t, testSuite.Chart.Version, "0.6.3")
@@ -809,7 +809,7 @@ tests:
 	chart, chartErr := v3loader.Load(testV3WithSubChart)
 	assert.NoError(t, chartErr)
 
-	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", false, &results.TestSuiteResult{})
 
 	assert.Empty(t, testSuite.Chart.AppVersion)
 	assert.Equal(t, testSuite.Chart.Version, "0.6.2")
@@ -835,7 +835,7 @@ tests:
 	assert.NoError(t, chartErr)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_nameoverride_failed_suite_test.yaml"), false)
-	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", false, &results.TestSuiteResult{})
 
 	validateTestResultAndSnapshots(t, suiteResult, true, "test suite name too long", 1, 0, 0, 0, 0)
 }
@@ -1426,7 +1426,7 @@ tests:
 	chart, chartErr := v3loader.Load(testV3BasicChart)
 	a.NoError(chartErr)
 
-	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", &results.TestSuiteResult{})
+	suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, true, "", false, &results.TestSuiteResult{})
 
 	a.True(suiteResult.FailFast)
 	a.False(suiteResult.Passed)
@@ -1458,7 +1458,7 @@ func TestV3RunSuiteWithSuite_With_EmptyTestJobs(t *testing.T) {
 			chart, chartErr := v3loader.Load(testV3BasicChart)
 			assert.NoError(t, chartErr)
 
-			suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, tt.failFast, "", &results.TestSuiteResult{})
+			suiteResult := testSuite.RunV3(chart, &snapshot.Cache{}, tt.failFast, "", false, &results.TestSuiteResult{})
 			assert.False(t, suiteResult.Passed)
 			assert.True(t, len(suiteResult.TestsResult) == 2)
 		})
@@ -1657,7 +1657,7 @@ tests:
 
 			// Run the suite
 			cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, fmt.Sprintf("skip-reason-snapshot-%s.yaml", tc.name)), false)
-			suiteResult := testSuite.RunV3(chart, cache, false, "", &results.TestSuiteResult{})
+			suiteResult := testSuite.RunV3(chart, cache, false, "", false, &results.TestSuiteResult{})
 
 			// Verify skipped status
 			a.True(suiteResult.Skipped)
@@ -1706,7 +1706,7 @@ func TestV3RunSuiteWithSkipTests(t *testing.T) {
 			chart, chartErr := v3loader.Load(testV3BasicChart)
 			assert.NoError(t, chartErr)
 
-			suiteResult := testSuite.RunV3(chart, cache, tt.failFast, "", &results.TestSuiteResult{})
+			suiteResult := testSuite.RunV3(chart, cache, tt.failFast, "", false, &results.TestSuiteResult{})
 
 			assert.False(t, suiteResult.Skipped)
 			assert.False(t, suiteResult.Passed)
@@ -1747,7 +1747,7 @@ func TestV3RunSuiteWithSuiteLevelSkip(t *testing.T) {
 			chart, chartErr := v3loader.Load(testV3BasicChart)
 			assert.NoError(t, chartErr)
 
-			suiteResult := testSuite.RunV3(chart, cache, tt.failFast, "", &results.TestSuiteResult{})
+			suiteResult := testSuite.RunV3(chart, cache, tt.failFast, "", false, &results.TestSuiteResult{})
 
 			assert.True(t, suiteResult.Skipped)
 			assert.True(t, suiteResult.Passed)


### PR DESCRIPTION
- Add plugin toggle to disable schema validation when needed
- Default is still validating schema's to ensure there is no change in behaviour
- Added / updated tests.