### PR TITLE
fix: avoid panic when documentSelector is missing path after previous test

### DIFF
--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -316,11 +316,14 @@ func (s *TestSuite) polishSkipSettings(test *TestJob) {
 	} else if s.Skip.Reason == "" {
 		skipped := 0
 		for _, test := range s.Tests {
+			if test == nil {
+				continue
+			}
 			if test.Skip.Reason != "" {
 				skipped++
 			}
 		}
-		if skipped == len(s.Tests) {
+		if skipped > 0 && skipped == len(s.Tests) {
 			s.Skip.Reason = "all tests are skipped"
 		}
 	}

--- a/pkg/unittest/testdata/chart-document-selector/tests/case4-error_test.yaml
+++ b/pkg/unittest/testdata/chart-document-selector/tests/case4-error_test.yaml
@@ -1,0 +1,17 @@
+suite: documentSelector invalid format should not panic after previous test
+templates:
+  - mixed-resource-types.yaml
+
+tests:
+  - it: warmup - run a simple assertion
+    asserts:
+      - contains:
+          path: kind
+          value: Deployment
+
+  - it: partial document selector in asserts, documentSelector.path is missing
+    asserts:
+      - exists:
+          path: kind
+        documentSelector:
+          skipEmptyTemplates: true

--- a/pkg/unittest/utils_test.go
+++ b/pkg/unittest/utils_test.go
@@ -186,6 +186,13 @@ func TestV3RunnerWith_Fixture_Chart_DocumentSelector(t *testing.T) {
 		},
 		{
 			chart:      "testdata/chart-document-selector",
+			testFlavor: "case4-error",
+			expected: []string{
+				"### Error:  empty 'documentSelector.path' not supported",
+			},
+		},
+		{
+			chart:      "testdata/chart-document-selector",
 			testFlavor: "case1-ok",
 			expected: []string{
 				"Test Suites: 2 passed, 2 total",


### PR DESCRIPTION
Fixes #812

This PR prevents a nil pointer panic when a test contains a partially
defined `documentSelector` (for example, missing the required `path` field)
after a previous test in the same suite.

Invalid user input now results in a validation error instead of a crash due to nil dereference panic.