### PR TITLE
docs: fix typos in markdown files and docker-build comment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,7 +20,7 @@ The testsuite is the starting point, the properties which you can set here are d
 | Features/Quirks | The feature | The quirk |
 | ------ | ----- | ----- |
 | When templates are defined, it filters only those templates | You can focus on only templates to be tests | templates that depends on other templates, need to be added to the list |
-| When release and/or capabillities are defined, it overrides the behavour of the chart itself | You can control the behaviour of the template rendering and have a predictable outcome | |
+| When release and/or capabilities are defined, it overrides the behaviour of the chart itself | You can control the behaviour of the template rendering and have a predictable outcome | |
 | When KubernetesProvider is used, it generates a Mock that can be used for e.g. Lookups | You can control the outcome of the rendering of dependend resources that are not part of the helm template | Only use the KubernetesProvider when you expect output, without the provider dependend resources return an empty object |
 
 #### Test Job(s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,7 +215,7 @@
 - Fix failed_template multi colon handling (resolves #200)
 - Fix glob all valid filenames (resolves #201)
 - Update packages to latest patch versions
-- Update documenation (thanks to @yariksheptykin)
+- Update documentation (thanks to @yariksheptykin)
 
 0.3.4 / 2023-08-01
 ===================
@@ -223,7 +223,7 @@
 - Fix/Refactor containsDocument validation, handles strict validation when multiple documents are found (resolves #167, resolves #173)
 - Fix schema definition types (resolves #174)
 - Fix validation of required fields in suite (resolves #178)
-- Remove GitHub API usage during instal (credits @raxod502-plaid, resolves #181)
+- Remove GitHub API usage during install (credits @raxod502-plaid, resolves #181)
 - Enable suite-level set block (resolves #155)
 - Update packages to latest patch versions
 - Update documentation
@@ -286,7 +286,7 @@
 0.2.9 / 2022-09-24
 ==================
 - Add JSON Schema for validating testsuite files (credits to: @armingerten, resolves quintush/helm-unittest#161)
-- Support failedTemplate assert schema for valdiation errors (credits to: @rquino)
+- Support failedTemplate assert schema for validation errors (credits to: @rquino)
 - Switch shell instead of bash to support other (credits to: @tewfik-ghariani)
 - Correct loading appVersion (resolves quintush/helm-unittest#172)
 - Update plugin to go 1.18
@@ -383,7 +383,7 @@
 
 0.1.7 / 2020-04-02
 ==================
-- added Helm V3 compatiblity (#87, #98)
+- added Helm V3 compatibility (#87, #98)
 - make install-binary.sh version aware (#97)
 
 0.1.6 / 2019-10-14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Issues and PRs are welcome!
 
 ## Issues and Improvements
 
-When you find an Issue or Improvement, please chech first if it already occurs
+When you find an Issue or Improvement, please check first if it already occurs
 otherwise create a [New Issue](https://github.com/helm-unittest/helm-unittest/issues/new/choose)
 
 If you have a Issue related to security, please follow our [Security Policy](./SECURITY.md)

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Prerequisite
-# Make sure you set secret enviroment variables in Circle CI
+# Make sure you set secret environment variables in Circle CI
 # DOCKER_USERNAME
 # DOCKER_PASSWORD
 # GITHUB_TOKEN


### PR DESCRIPTION
## Summary
While reading `CONTRIBUTING.md` for my previous PR, I noticed a typo.  
Then I reviewed and fixed other typo-only issues that do not affect any behavior.

## Changes
- Fixed typo(s) in `CONTRIBUTING.md`
- Fixed typo(s) in `ARCHITECTURE.md`
- Fixed typo(s) in `CHANGELOG.md`
- Fixed a typo in a comment in `docker-build.sh`

## Notes
- No functional changes
- No behavior changes
- I am not fully sure whether `CHANGELOG.md` should be included in this PR; I can revert those changes if preferred.
