### PR TITLE
feat(coverage): add template coverage reporting (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ Output columns:
   "`N iters`" annotation is the total iteration count summed across every
   test run, so a `range` over a large list shows real loop volume even when
   the binary coverage stat is 100%.
+* **Used** — `yes` if the template rendered non-empty content in any test,
+  or (for `_*.tpl` partials) if any of its `define`-block probes were hit
+  via `template` / `include`. `no` flags dead templates that no test
+  exercises, which the action/branch/loop columns alone can't always
+  surface (e.g. a static-YAML template that's never rendered shows `-` for
+  all three but `no` for Used). The footer row shows the rendered count as
+  `used/total`.
 
 Use `--coverage-file path/to/report` to emit a machine-readable report; this
 flag implies `--coverage`. The format is controlled by `--coverage-format`:
@@ -247,6 +254,18 @@ Action probes are reported as line coverage (Cobertura `<line>` / LCOV `DA`);
 branch and loop probes are reported as branches (Cobertura `condition-coverage`
 attribute / LCOV `BRDA`). Templates that failed to parse appear in the report
 with empty counters so consumers still see them in the file list.
+
+The per-file **Rendered** signal (whether any test caused this template to
+contribute output) is surfaced in every format:
+
+* JSON: `"rendered": true|false` on each file entry.
+* Cobertura: `helm-unittest-rendered="true|false"` attribute on each `<class>`
+  element (a non-standard extension that compliant consumers ignore).
+* LCOV: a `# helm-unittest:rendered=true|false` comment line emitted right
+  after each `SF:` record. Standard `genhtml` / `lcov` tooling tolerates the
+  comment.
+* HTML: a green `used` / red `unused` pill next to each filename and a count
+  in the summary.
 
 ### Yaml JsonPath Support
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,37 @@ defined in test suite files.
       --coverage-format string format for --coverage-file: json | cobertura | lcov (default json)
 ```
 
+### Installing from a Fork or Branch
+
+`install-binary.sh` first tries to download a prebuilt release tarball
+matching `plugin.yaml`'s `version` from the GitHub repo named in
+`PROJECT_GH` (default `helm-unittest/helm-unittest`). For a fork branch
+that has no matching release, this would silently install the wrong
+binary, so the script now:
+
+1. Detects fork installs automatically — if the cloned repo's
+   `origin` remote does not point at `helm-unittest/helm-unittest`, the
+   script builds the binary from source instead of downloading.
+2. Falls back to building from source when the prebuilt download fails
+   (404, network error, etc.) and a Go toolchain is available.
+
+Environment knobs:
+
+| Variable | Effect |
+|---|---|
+| `BUILD_FROM_SOURCE=1` | Skip the download path entirely and always build from source. Requires `go` on `PATH`. |
+| `HELM_UNITTEST_PROJECT_GH=<owner>/<repo>` | Download prebuilt binaries from a fork that publishes its own releases. Disables the fork-detection short-circuit. |
+| `SKIP_BIN_DOWNLOAD=1` | Use a pre-staged `untt` binary already sitting next to the script. |
+| `SKIP_BIN_INSTALL=1` | Don't install a binary at all (script noop). |
+
+So CI pipelines can pin to a fork branch with:
+
+```bash
+helm plugin install https://github.com/<owner>/helm-unittest.git --version <branch-or-tag>
+```
+
+and the source build runs automatically (Go is required on the runner).
+
 ### Code Coverage
 
 Pass `--coverage` to print a per-template coverage table after the test summary.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,45 @@ defined in test suite files.
   -u, --update-snapshot        update the snapshot cached if needed, make sure you review the change before update
   -s, --with-subchart charts   include tests of the subcharts within charts folder (default true)
       --chart-tests-path string the folder location relative to the chart where a helm chart to render test suites is located
+      --coverage               enable code coverage reporting for chart templates (default false)
+      --coverage-file string   write coverage report to the given path (implies --coverage)
+      --coverage-format string format for --coverage-file: json | cobertura | lcov (default json)
 ```
+
+### Code Coverage
+
+Pass `--coverage` to print a per-template coverage table after the test summary.
+Each chart template is instrumented by parsing its Go-template AST and injecting
+probe tokens at action, branch and range constructs; helm-unittest then renders
+each test job a second time through the instrumented chart and counts the
+tokens that survived in the output. Coverage rendering is isolated from the
+assertion render, so adding `--coverage` never changes test results.
+
+Output columns:
+
+* **Actions** — `{{ ... }}` expressions executed at least once.
+* **Branches** — `if`, `else`, `with`, `with-else` bodies, plus implicit
+  branches for `default` and `ternary` calls (primary vs fallback / true vs
+  false) when the call sits at the end of a pipeline with a simple field or
+  variable input.
+* **Loops** — `range` body / `range-else` entered at least once. The trailing
+  "`N iters`" annotation is the total iteration count summed across every
+  test run, so a `range` over a large list shows real loop volume even when
+  the binary coverage stat is 100%.
+
+Use `--coverage-file path/to/report` to emit a machine-readable report; this
+flag implies `--coverage`. The format is controlled by `--coverage-format`:
+
+| Format      | Flag value   | Consumed by                                                         |
+|-------------|--------------|---------------------------------------------------------------------|
+| JSON (default) | `json`    | Custom dashboards, this repo's own schema                           |
+| Cobertura XML | `cobertura` | Codecov, SonarQube, GitLab, Jenkins (Cobertura plugin), Azure DevOps |
+| LCOV        | `lcov`       | Coveralls, Codecov, VS Code "Coverage Gutters", JetBrains import    |
+
+Action probes are reported as line coverage (Cobertura `<line>` / LCOV `DA`);
+branch and loop probes are reported as branches (Cobertura `condition-coverage`
+attribute / LCOV `BRDA`). Templates that failed to parse appear in the report
+with empty counters so consumers still see them in the file list.
 
 ### Yaml JsonPath Support
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,10 @@ defined in test suite files.
       --chart-tests-path string the folder location relative to the chart where a helm chart to render test suites is located
       --coverage               enable code coverage reporting for chart templates (default false)
       --coverage-file string   write coverage report to the given path (implies --coverage)
-      --coverage-format string format for --coverage-file: json | cobertura | lcov | html (default json)
+      --coverage-format string format(s) for --coverage-file: json | cobertura | lcov | html.
+                               Comma-separated for multi-format (e.g. cobertura,lcov,html);
+                               --coverage-file is then a path stem and per-format extensions
+                               are appended. (default json)
 ```
 
 ### Installing from a Fork or Branch
@@ -241,7 +244,8 @@ Output columns:
   `used/total`.
 
 Use `--coverage-file path/to/report` to emit a machine-readable report; this
-flag implies `--coverage`. The format is controlled by `--coverage-format`:
+flag implies `--coverage`. The format is controlled by `--coverage-format`,
+which accepts a single format or a comma-separated list:
 
 | Format      | Flag value    | Consumed by                                                          |
 |-------------|---------------|----------------------------------------------------------------------|
@@ -254,6 +258,25 @@ Action probes are reported as line coverage (Cobertura `<line>` / LCOV `DA`);
 branch and loop probes are reported as branches (Cobertura `condition-coverage`
 attribute / LCOV `BRDA`). Templates that failed to parse appear in the report
 with empty counters so consumers still see them in the file list.
+
+For a **single** format, `--coverage-file` is the exact output path. For
+**multiple** formats, `--coverage-file` is treated as a path stem; each
+format appends its conventional extension automatically — and a trailing
+known extension on the stem (e.g. `coverage.xml`) is stripped first so you
+don't end up with `coverage.xml.xml`. Example:
+
+```bash
+helm unittest \
+  --coverage-format cobertura,lcov,html,json \
+  --coverage-file ./reports/cov \
+  <chart>
+
+# writes:
+#   ./reports/cov.xml    (cobertura)
+#   ./reports/cov.info   (lcov)
+#   ./reports/cov.html   (html)
+#   ./reports/cov.json   (json)
+```
 
 The per-file **Rendered** signal (whether any test caused this template to
 contribute output) is surfaced in every format:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ defined in test suite files.
       --chart-tests-path string the folder location relative to the chart where a helm chart to render test suites is located
       --coverage               enable code coverage reporting for chart templates (default false)
       --coverage-file string   write coverage report to the given path (implies --coverage)
-      --coverage-format string format for --coverage-file: json | cobertura | lcov (default json)
+      --coverage-format string format for --coverage-file: json | cobertura | lcov | html (default json)
 ```
 
 ### Installing from a Fork or Branch
@@ -236,11 +236,12 @@ Output columns:
 Use `--coverage-file path/to/report` to emit a machine-readable report; this
 flag implies `--coverage`. The format is controlled by `--coverage-format`:
 
-| Format      | Flag value   | Consumed by                                                         |
-|-------------|--------------|---------------------------------------------------------------------|
-| JSON (default) | `json`    | Custom dashboards, this repo's own schema                           |
+| Format      | Flag value    | Consumed by                                                          |
+|-------------|---------------|----------------------------------------------------------------------|
+| JSON (default) | `json`     | Custom dashboards, this repo's own schema                            |
 | Cobertura XML | `cobertura` | Codecov, SonarQube, GitLab, Jenkins (Cobertura plugin), Azure DevOps |
-| LCOV        | `lcov`       | Coveralls, Codecov, VS Code "Coverage Gutters", JetBrains import    |
+| LCOV          | `lcov`      | Coveralls, Codecov, VS Code "Coverage Gutters", JetBrains import     |
+| HTML          | `html`      | Standalone single-file page — open in any browser, attach as a CI artifact. Source code is embedded with per-line colour coding (covered / missed / partial) and a sortable file list. |
 
 Action probes are reported as line coverage (Cobertura `<line>` / LCOV `DA`);
 branch and loop probes are reported as branches (Cobertura `condition-coverage`

--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ Output columns:
   all three but `no` for Used). The footer row shows the rendered count as
   `used/total`.
 
+Coverage respects the existing `--with-subchart` flag: when it's set to
+`false`, subchart templates are excluded from coverage instrumentation and
+the report. They are still copied into the chart that's rendered for
+coverage so `include "subchart.foo"` calls from the parent chart still
+work — only their probes and report rows are dropped.
+
 Use `--coverage-file path/to/report` to emit a machine-readable report; this
 flag implies `--coverage`. The format is controlled by `--coverage-format`,
 which accepts a single format or a comma-separated list:

--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -206,7 +206,7 @@ func InitPluginFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringVar(
 		&testConfig.coverageFormat, "coverage-format", "json",
-		"format for --coverage-file: json | cobertura | lcov",
+		"format for --coverage-file: json | cobertura | lcov | html",
 	)
 }
 

--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -206,7 +206,7 @@ func InitPluginFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringVar(
 		&testConfig.coverageFormat, "coverage-format", "json",
-		"format for --coverage-file: json | cobertura | lcov | html",
+		"format(s) for --coverage-file: json | cobertura | lcov | html. Comma-separated for multiple (e.g. cobertura,lcov,html); in that case --coverage-file is used as a path stem and per-format extensions are appended (.xml/.info/.html/.json)",
 	)
 }
 

--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -21,6 +21,9 @@ type testOptions struct {
 	colored        bool
 	updateSnapshot bool
 	withSubChart   bool
+	coverage       bool
+	coverageFile   string
+	coverageFormat string
 	testFiles      []string
 	valuesFiles    []string
 	outputFile     string
@@ -88,6 +91,10 @@ func RunPlugin(cmd *cobra.Command, chartPaths []string) {
 		testConfig.testFiles = []string{defaultFilePattern}
 	}
 
+	if testConfig.coverageFile != "" {
+		testConfig.coverage = true
+	}
+
 	formatter := formatter.NewFormatter(testConfig.outputFile, testConfig.outputType)
 	printer := printer.NewPrinter(os.Stdout, colored)
 	testRunner = unittest.TestRunner{
@@ -97,6 +104,9 @@ func RunPlugin(cmd *cobra.Command, chartPaths []string) {
 		WithSubChart:   testConfig.withSubChart,
 		Strict:         testConfig.useStrict,
 		Failfast:       testConfig.useFailfast,
+		Coverage:       testConfig.coverage,
+		CoverageFile:   testConfig.coverageFile,
+		CoverageFormat: testConfig.coverageFormat,
 		TestFiles:      testConfig.testFiles,
 		ValuesFiles:    testConfig.valuesFiles,
 		OutputFile:     testConfig.outputFile,
@@ -182,6 +192,21 @@ func InitPluginFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(
 		&testConfig.debugLogging, "debugPlugin", "d", false,
 		"enable verbose output",
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&testConfig.coverage, "coverage", false,
+		"enable code coverage reporting for chart templates",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&testConfig.coverageFile, "coverage-file", "",
+		"write coverage report to the given path (implies --coverage)",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&testConfig.coverageFormat, "coverage-format", "json",
+		"format for --coverage-file: json | cobertura | lcov",
 	)
 }
 

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -3,7 +3,10 @@
 # borrowed from https://github.com/technosophos/helm-template
 
 PROJECT_NAME="helm-unittest"
-PROJECT_GH="helm-unittest/$PROJECT_NAME"
+# PROJECT_GH can be overridden via HELM_UNITTEST_PROJECT_GH so forks that
+# publish their own prebuilt releases (e.g. owner/helm-unittest) are picked
+# up instead of upstream.
+PROJECT_GH="${HELM_UNITTEST_PROJECT_GH:-helm-unittest/$PROJECT_NAME}"
 PROJECT_CHECKSUM_FILE="$PROJECT_NAME-checksum.sha"
 HELM_PLUGIN_PATH="$HELM_PLUGIN_DIR"
 
@@ -27,7 +30,35 @@ if [ "$SKIP_BIN_DOWNLOAD" = "1" ]; then
   cp -f untt $HELM_PLUGIN_PATH/untt
   chmod +x $HELM_PLUGIN_PATH/untt
   echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH"
-  exit 
+  exit
+fi
+
+# buildFromSource compiles the plugin binary from the repository checkout
+# Helm has cloned into $HELM_PLUGIN_PATH. Used for fork branches / custom
+# tags that don't have a matching prebuilt release.
+buildFromSource() {
+  echo "Building $PROJECT_NAME from source in $HELM_PLUGIN_PATH"
+  if ! type "go" >/dev/null 2>&1; then
+    echo "Cannot build from source: 'go' is not on PATH."
+    echo "Install Go 1.24+ or set HELM_UNITTEST_PROJECT_GH to a fork that publishes releases."
+    return 1
+  fi
+  if [ ! -f "$HELM_PLUGIN_PATH/go.mod" ]; then
+    echo "Cannot build from source: no go.mod found in $HELM_PLUGIN_PATH."
+    return 1
+  fi
+  (cd "$HELM_PLUGIN_PATH" && go build -o untt ./cmd/helm-unittest) || return 1
+  chmod +x "$HELM_PLUGIN_PATH/untt"
+  echo "$PROJECT_NAME built from source into $HELM_PLUGIN_PATH"
+  return 0
+}
+
+# Explicit opt-in: build straight from source without trying the download
+# path. Useful in CI when you know the install must use the checked-out
+# branch and not whatever happens to be tagged in plugin.yaml.
+if [ "$BUILD_FROM_SOURCE" = "1" ] || [ "$BUILD_FROM_SOURCE" = "true" ]; then
+  buildFromSource && exit 0
+  exit 1
 fi
 
 # initArch discovers the architecture for this system.
@@ -98,7 +129,10 @@ downloadFile() {
   mkdir -p "$PLUGIN_TMP_FOLDER"
   echo "Downloading "$DOWNLOAD_URL" to location $PLUGIN_TMP_FOLDER"
   if type "curl" >/dev/null 2>&1; then
-      (cd "$PLUGIN_TMP_FOLDER" && curl -LO "$DOWNLOAD_URL")
+      # -f makes curl exit non-zero on HTTP errors (404 etc.) instead of
+      # silently writing an HTML error page to disk; the auto-fallback to a
+      # source build depends on that.
+      (cd "$PLUGIN_TMP_FOLDER" && curl -f -LO "$DOWNLOAD_URL")
   elif type "wget" >/dev/null 2>&1; then
       wget -P "$PLUGIN_TMP_FOLDER" "$DOWNLOAD_URL"
   fi
@@ -164,6 +198,28 @@ testVersion() {
   untt -h
 }
 
+# detectFork returns 0 if the cloned repo's `origin` remote is NOT the
+# canonical upstream and the user has not overridden PROJECT_GH. This is the
+# `helm plugin install https://github.com/<fork>/helm-unittest.git ...` case:
+# downloading a release tarball from upstream would silently install a
+# different binary than the user's fork-branch contains, so we build from
+# source instead.
+detectFork() {
+  # If the user explicitly told us where to download from, trust them.
+  if [ -n "$HELM_UNITTEST_PROJECT_GH" ]; then
+    return 1
+  fi
+  if [ ! -d "$HELM_PLUGIN_PATH/.git" ]; then
+    return 1
+  fi
+  local remoteUrl
+  remoteUrl=$(cd "$HELM_PLUGIN_PATH" && git config --get remote.origin.url 2>/dev/null || echo "")
+  case "$remoteUrl" in
+    ""|*helm-unittest/helm-unittest*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 # Execution
 
 #Stop execution on any error
@@ -171,8 +227,22 @@ trap "fail_trap" EXIT
 set -e
 initArch
 initOS
-verifySupported
-getDownloadURL
-downloadFile
-installFile
-testVersion
+
+# Fork installs (where origin points at a non-upstream repo) build from
+# source so the user's branch contents are what actually runs.
+if detectFork; then
+  echo "Detected fork install: building from source so the checked-out branch is used."
+  buildFromSource && testVersion && exit 0
+  exit 1
+fi
+
+# Try the prebuilt-release path first; if any step in it errors, fall back to
+# a source build when a Go toolchain is available.
+if (set -e; verifySupported && getDownloadURL && downloadFile && installFile); then
+  testVersion
+else
+  echo
+  echo "Prebuilt download was unavailable (likely because plugin.yaml's version does not match a published release on $PROJECT_GH)."
+  echo "Falling back to building from source."
+  buildFromSource && testVersion
+fi

--- a/pkg/unittest/coverage/cobertura.go
+++ b/pkg/unittest/coverage/cobertura.go
@@ -1,0 +1,193 @@
+package coverage
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WriteCobertura emits a Cobertura-compatible XML report at path. The format
+// follows the Cobertura 04 DTD that Codecov, GitLab, Jenkins, SonarQube and
+// Azure DevOps all consume. Action probes are mapped to Cobertura "lines" and
+// every branch/loop probe contributes a Cobertura "condition" on its line.
+func WriteCobertura(path string, cov Coverage) error {
+	doc := buildCobertura(cov)
+
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.WriteString(f, xml.Header); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(f, coberturaDoctype); err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(f)
+	enc.Indent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return err
+	}
+	_, err = io.WriteString(f, "\n")
+	return err
+}
+
+const coberturaDoctype = `<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">` + "\n"
+
+type coberturaCoverage struct {
+	XMLName         xml.Name           `xml:"coverage"`
+	LineRate        string             `xml:"line-rate,attr"`
+	BranchRate      string             `xml:"branch-rate,attr"`
+	LinesCovered    int                `xml:"lines-covered,attr"`
+	LinesValid      int                `xml:"lines-valid,attr"`
+	BranchesCovered int                `xml:"branches-covered,attr"`
+	BranchesValid   int                `xml:"branches-valid,attr"`
+	Complexity      string             `xml:"complexity,attr"`
+	Version         string             `xml:"version,attr"`
+	Timestamp       int64              `xml:"timestamp,attr"`
+	Sources         coberturaSources   `xml:"sources"`
+	Packages        coberturaPackages  `xml:"packages"`
+}
+
+type coberturaSources struct {
+	Sources []string `xml:"source"`
+}
+
+type coberturaPackages struct {
+	Packages []coberturaPackage `xml:"package"`
+}
+
+type coberturaPackage struct {
+	Name       string            `xml:"name,attr"`
+	LineRate   string            `xml:"line-rate,attr"`
+	BranchRate string            `xml:"branch-rate,attr"`
+	Complexity string            `xml:"complexity,attr"`
+	Classes    coberturaClasses  `xml:"classes"`
+}
+
+type coberturaClasses struct {
+	Classes []coberturaClass `xml:"class"`
+}
+
+type coberturaClass struct {
+	Name       string             `xml:"name,attr"`
+	Filename   string             `xml:"filename,attr"`
+	LineRate   string             `xml:"line-rate,attr"`
+	BranchRate string             `xml:"branch-rate,attr"`
+	Complexity string             `xml:"complexity,attr"`
+	Methods    coberturaMethods   `xml:"methods"`
+	Lines      coberturaLineList  `xml:"lines"`
+}
+
+type coberturaMethods struct{}
+
+type coberturaLineList struct {
+	Lines []coberturaLine `xml:"line"`
+}
+
+type coberturaLine struct {
+	Number            int    `xml:"number,attr"`
+	Hits              int    `xml:"hits,attr"`
+	Branch            string `xml:"branch,attr"`
+	ConditionCoverage string `xml:"condition-coverage,attr,omitempty"`
+}
+
+func buildCobertura(cov Coverage) coberturaCoverage {
+	doc := coberturaCoverage{
+		Version:   "helm-unittest",
+		Timestamp: time.Now().Unix() * 1000,
+		Sources:   coberturaSources{Sources: []string{"."}},
+		Complexity: "0",
+	}
+
+	// Cobertura's top-level rates are computed across all files. We use:
+	//   line-rate   = action coverage (each action probe is a "line of code")
+	//   branch-rate = combined branch + loop coverage
+	totalLines := cov.Totals.Actions
+	totalBranches := CountStat{
+		Covered: cov.Totals.Branches.Covered + cov.Totals.Loops.Covered,
+		Total:   cov.Totals.Branches.Total + cov.Totals.Loops.Total,
+	}
+	doc.LinesCovered = totalLines.Covered
+	doc.LinesValid = totalLines.Total
+	doc.BranchesCovered = totalBranches.Covered
+	doc.BranchesValid = totalBranches.Total
+	doc.LineRate = formatRate(totalLines)
+	doc.BranchRate = formatRate(totalBranches)
+
+	pkg := coberturaPackage{
+		Name:       cov.ChartName,
+		LineRate:   formatRate(totalLines),
+		BranchRate: formatRate(totalBranches),
+		Complexity: "0",
+	}
+
+	for _, f := range cov.Files {
+		if f.ParseError != nil {
+			continue
+		}
+		class := coberturaClass{
+			Name:       classNameFromPath(f.Name),
+			Filename:   f.Name,
+			LineRate:   formatRate(f.Actions),
+			BranchRate: formatRate(CountStat{Covered: f.Branches.Covered + f.Loops.Covered, Total: f.Branches.Total + f.Loops.Total}),
+			Complexity: "0",
+		}
+		for _, ln := range f.Lines {
+			cl := coberturaLine{
+				Number: ln.Line,
+				Hits:   ln.Hits,
+				Branch: "false",
+			}
+			if n := len(ln.Branches); n > 0 {
+				cl.Branch = "true"
+				taken := 0
+				for _, b := range ln.Branches {
+					if b.Hits > 0 {
+						taken++
+					}
+				}
+				cl.ConditionCoverage = fmt.Sprintf("%d%% (%d/%d)", percentInt(taken, n), taken, n)
+			}
+			class.Lines.Lines = append(class.Lines.Lines, cl)
+		}
+		pkg.Classes.Classes = append(pkg.Classes.Classes, class)
+	}
+	doc.Packages.Packages = append(doc.Packages.Packages, pkg)
+	return doc
+}
+
+// classNameFromPath converts a slash-separated template path into a
+// dot-separated Cobertura class name. e.g.
+//
+//	chart-subchart-v1/templates/configmap.yaml
+//	-> chart-subchart-v1.templates.configmap_yaml
+func classNameFromPath(p string) string {
+	dir := filepath.ToSlash(filepath.Dir(p))
+	base := filepath.Base(p)
+	base = strings.ReplaceAll(base, ".", "_")
+	if dir == "." || dir == "" {
+		return base
+	}
+	return strings.ReplaceAll(dir, "/", ".") + "." + base
+}
+
+func formatRate(s CountStat) string {
+	if s.Total == 0 {
+		return "1"
+	}
+	return fmt.Sprintf("%.4f", float64(s.Covered)/float64(s.Total))
+}
+
+func percentInt(covered, total int) int {
+	if total == 0 {
+		return 0
+	}
+	return int(100 * float64(covered) / float64(total))
+}

--- a/pkg/unittest/coverage/cobertura.go
+++ b/pkg/unittest/coverage/cobertura.go
@@ -76,13 +76,17 @@ type coberturaClasses struct {
 }
 
 type coberturaClass struct {
-	Name       string             `xml:"name,attr"`
-	Filename   string             `xml:"filename,attr"`
-	LineRate   string             `xml:"line-rate,attr"`
-	BranchRate string             `xml:"branch-rate,attr"`
-	Complexity string             `xml:"complexity,attr"`
-	Methods    coberturaMethods   `xml:"methods"`
-	Lines      coberturaLineList  `xml:"lines"`
+	Name       string            `xml:"name,attr"`
+	Filename   string            `xml:"filename,attr"`
+	LineRate   string            `xml:"line-rate,attr"`
+	BranchRate string            `xml:"branch-rate,attr"`
+	Complexity string            `xml:"complexity,attr"`
+	// HelmUnittestRendered is a helm-unittest extension attribute. Standard
+	// Cobertura consumers ignore unknown attributes, so this is safe; tooling
+	// that knows to look for it can use it to surface unused templates.
+	HelmUnittestRendered string             `xml:"helm-unittest-rendered,attr"`
+	Methods              coberturaMethods   `xml:"methods"`
+	Lines                coberturaLineList  `xml:"lines"`
 }
 
 type coberturaMethods struct{}
@@ -133,11 +137,12 @@ func buildCobertura(cov Coverage) coberturaCoverage {
 			continue
 		}
 		class := coberturaClass{
-			Name:       classNameFromPath(f.Name),
-			Filename:   f.Name,
-			LineRate:   formatRate(f.Actions),
-			BranchRate: formatRate(CountStat{Covered: f.Branches.Covered + f.Loops.Covered, Total: f.Branches.Total + f.Loops.Total}),
-			Complexity: "0",
+			Name:                 classNameFromPath(f.Name),
+			Filename:             f.Name,
+			LineRate:             formatRate(f.Actions),
+			BranchRate:           formatRate(CountStat{Covered: f.Branches.Covered + f.Loops.Covered, Total: f.Branches.Total + f.Loops.Total}),
+			Complexity:           "0",
+			HelmUnittestRendered: fmt.Sprintf("%t", f.Rendered),
 		}
 		for _, ln := range f.Lines {
 			cl := coberturaLine{

--- a/pkg/unittest/coverage/cobertura_test.go
+++ b/pkg/unittest/coverage/cobertura_test.go
@@ -1,0 +1,88 @@
+package coverage
+
+import (
+	"encoding/xml"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleCoverage() Coverage {
+	cov := Coverage{ChartName: "demo"}
+	cov.Files = []FileCoverage{
+		{
+			Name:    "demo/templates/cm.yaml",
+			Actions: CountStat{Covered: 2, Total: 3},
+			Branches: CountStat{Covered: 1, Total: 2},
+			Loops:   CountStat{Covered: 0, Total: 1},
+			Lines: []LineCoverage{
+				{Line: 4, Hits: 2},
+				{Line: 6, Hits: 0, Branches: []BranchCoverage{{Label: "if", Hits: 0}, {Label: "else", Hits: 2}}},
+				{Line: 9, Hits: 0, Branches: []BranchCoverage{{Label: "range-body", Hits: 0}}},
+			},
+		},
+		{
+			Name:       "demo/templates/broken.yaml",
+			ParseError: errors.New("synthetic"),
+		},
+	}
+	cov.Totals.Actions = CountStat{Covered: 2, Total: 3}
+	cov.Totals.Branches = CountStat{Covered: 1, Total: 2}
+	cov.Totals.Loops = CountStat{Covered: 0, Total: 1}
+	return cov
+}
+
+func TestWriteCobertura_StructureAndCounts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cobertura.xml")
+	require.NoError(t, WriteCobertura(path, sampleCoverage()))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	contents := string(data)
+
+	// Header + DOCTYPE present so Cobertura-aware tools accept the file.
+	assert.True(t, strings.HasPrefix(contents, `<?xml`), "missing XML header")
+	assert.Contains(t, contents, "coverage-04.dtd")
+
+	var doc coberturaCoverage
+	require.NoError(t, xml.Unmarshal(data, &doc))
+
+	// Top-level totals come from actions (lines) and branches+loops combined.
+	assert.Equal(t, 2, doc.LinesCovered)
+	assert.Equal(t, 3, doc.LinesValid)
+	assert.Equal(t, 1, doc.BranchesCovered)
+	assert.Equal(t, 3, doc.BranchesValid)
+
+	require.Len(t, doc.Packages.Packages, 1)
+	pkg := doc.Packages.Packages[0]
+	assert.Equal(t, "demo", pkg.Name)
+
+	// Parse-error files must not appear as classes in the package.
+	require.Len(t, pkg.Classes.Classes, 1)
+	cls := pkg.Classes.Classes[0]
+	assert.Equal(t, "demo/templates/cm.yaml", cls.Filename)
+	require.Len(t, cls.Lines.Lines, 3)
+
+	// Branch line should be marked and carry condition-coverage attribute.
+	branchLine := cls.Lines.Lines[1]
+	assert.Equal(t, 6, branchLine.Number)
+	assert.Equal(t, "true", branchLine.Branch)
+	assert.Contains(t, branchLine.ConditionCoverage, "1/2")
+}
+
+func TestClassNameFromPath(t *testing.T) {
+	cases := map[string]string{
+		"demo/templates/cm.yaml":              "demo.templates.cm_yaml",
+		"demo/templates/sub/dir/cm.yaml":      "demo.templates.sub.dir.cm_yaml",
+		"cm.yaml":                             "cm_yaml",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, classNameFromPath(in), in)
+	}
+}

--- a/pkg/unittest/coverage/cobertura_test.go
+++ b/pkg/unittest/coverage/cobertura_test.go
@@ -16,15 +16,21 @@ func sampleCoverage() Coverage {
 	cov := Coverage{ChartName: "demo"}
 	cov.Files = []FileCoverage{
 		{
-			Name:    "demo/templates/cm.yaml",
-			Actions: CountStat{Covered: 2, Total: 3},
+			Name:     "demo/templates/cm.yaml",
+			Rendered: true,
+			Actions:  CountStat{Covered: 2, Total: 3},
 			Branches: CountStat{Covered: 1, Total: 2},
-			Loops:   CountStat{Covered: 0, Total: 1},
+			Loops:    CountStat{Covered: 0, Total: 1},
 			Lines: []LineCoverage{
 				{Line: 4, Hits: 2},
 				{Line: 6, Hits: 0, Branches: []BranchCoverage{{Label: "if", Hits: 0}, {Label: "else", Hits: 2}}},
 				{Line: 9, Hits: 0, Branches: []BranchCoverage{{Label: "range-body", Hits: 0}}},
 			},
+		},
+		{
+			Name:     "demo/templates/dead.yaml",
+			Rendered: false,
+			Actions:  CountStat{Covered: 0, Total: 1},
 		},
 		{
 			Name:       "demo/templates/broken.yaml",
@@ -63,17 +69,24 @@ func TestWriteCobertura_StructureAndCounts(t *testing.T) {
 	pkg := doc.Packages.Packages[0]
 	assert.Equal(t, "demo", pkg.Name)
 
-	// Parse-error files must not appear as classes in the package.
-	require.Len(t, pkg.Classes.Classes, 1)
-	cls := pkg.Classes.Classes[0]
-	assert.Equal(t, "demo/templates/cm.yaml", cls.Filename)
-	require.Len(t, cls.Lines.Lines, 3)
+	// Parse-error files must not appear as classes; rendered AND unused files do.
+	require.Len(t, pkg.Classes.Classes, 2)
+	byName := map[string]coberturaClass{}
+	for _, c := range pkg.Classes.Classes {
+		byName[c.Filename] = c
+	}
 
+	cm := byName["demo/templates/cm.yaml"]
+	require.Len(t, cm.Lines.Lines, 3)
+	assert.Equal(t, "true", cm.HelmUnittestRendered, "rendered template should be flagged")
 	// Branch line should be marked and carry condition-coverage attribute.
-	branchLine := cls.Lines.Lines[1]
+	branchLine := cm.Lines.Lines[1]
 	assert.Equal(t, 6, branchLine.Number)
 	assert.Equal(t, "true", branchLine.Branch)
 	assert.Contains(t, branchLine.ConditionCoverage, "1/2")
+
+	dead := byName["demo/templates/dead.yaml"]
+	assert.Equal(t, "false", dead.HelmUnittestRendered, "unrendered template should be flagged")
 }
 
 func TestClassNameFromPath(t *testing.T) {

--- a/pkg/unittest/coverage/html.go
+++ b/pkg/unittest/coverage/html.go
@@ -1,0 +1,257 @@
+package coverage
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"io"
+	"os"
+	"strings"
+)
+
+// WriteHTML writes a self-contained HTML coverage report at path. The output
+// has no external dependencies (no JS, no CDN-hosted CSS) so it works as a
+// CI artifact or as a file opened directly in a browser. Each template's
+// source is embedded inline with per-line colour coding sourced from the
+// per-probe hit counts; clicking a row in the file list jumps to that file's
+// source block.
+func WriteHTML(path string, cov Coverage) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return renderHTML(f, cov)
+}
+
+func renderHTML(w io.Writer, cov Coverage) error {
+	var b strings.Builder
+	writeHTMLHead(&b, cov)
+	writeHTMLSummary(&b, cov)
+	writeHTMLFileList(&b, cov)
+	for _, file := range cov.Files {
+		writeHTMLFileView(&b, file)
+	}
+	writeHTMLFoot(&b)
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+const htmlStyles = `
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+         margin: 24px; color: #1f2328; background: #ffffff; }
+  h1 { margin: 0 0 4px 0; font-size: 22px; }
+  .subtitle { color: #57606a; margin-bottom: 24px; font-size: 13px; }
+  .summary { display: flex; gap: 12px; margin-bottom: 24px; flex-wrap: wrap; }
+  .stat { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+          padding: 10px 16px; min-width: 140px; }
+  .stat .label { font-size: 11px; color: #57606a; text-transform: uppercase; letter-spacing: .04em; }
+  .stat .value { font-size: 22px; font-weight: 600; margin-top: 2px; }
+  .stat .sub { font-size: 12px; color: #57606a; margin-top: 2px; }
+  table.files { width: 100%; border-collapse: collapse; margin-bottom: 32px; font-size: 13px; }
+  .files th, .files td { text-align: left; padding: 6px 12px; border-bottom: 1px solid #d0d7de; }
+  .files th { font-weight: 600; background: #f6f8fa; }
+  .files td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .files a { color: #0969da; text-decoration: none; }
+  .files a:hover { text-decoration: underline; }
+  .pct-high { color: #1a7f37; }
+  .pct-mid  { color: #9a6700; }
+  .pct-low  { color: #cf222e; }
+  .pct-na   { color: #6e7781; }
+  details.file { margin: 10px 0; border: 1px solid #d0d7de; border-radius: 6px; overflow: hidden; }
+  details.file summary { background: #f6f8fa; padding: 8px 12px; cursor: pointer; font-weight: 600;
+                         display: flex; gap: 16px; align-items: baseline; }
+  details.file summary .badges { margin-left: auto; font-weight: 400; font-size: 12px; color: #57606a; }
+  table.source { width: 100%; border-collapse: collapse;
+                 font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+  .source td { padding: 0 8px; vertical-align: top; }
+  .source .lineno { color: #6e7781; text-align: right; width: 1%; user-select: none;
+                    background: #f6f8fa; border-right: 1px solid #d0d7de; }
+  .source .hits   { color: #6e7781; text-align: right; width: 1%; font-variant-numeric: tabular-nums;
+                    background: #f6f8fa; border-right: 1px solid #d0d7de; }
+  .source .code   { white-space: pre; }
+  .source tr.covered .code { background: #ddf4e4; }
+  .source tr.missed  .code { background: #ffebe9; }
+  .source tr.partial .code { background: #fff8c5; }
+  .source tr.neutral .code { background: transparent; }
+  .parse-error { padding: 10px 14px; background: #ffebe9; color: #cf222e; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #c9d1d9; background: #0d1117; }
+    .stat, .files th, details.file summary,
+    .source .lineno, .source .hits { background: #161b22; border-color: #30363d; }
+    .files th, .files td { border-bottom-color: #30363d; }
+    details.file { border-color: #30363d; }
+    .source tr.covered .code { background: #1b4721; }
+    .source tr.missed  .code { background: #5a1d1a; }
+    .source tr.partial .code { background: #5c4a00; }
+    .parse-error { background: #5a1d1a; color: #ffa198; }
+  }
+`
+
+func writeHTMLHead(b *strings.Builder, cov Coverage) {
+	fmt.Fprintf(b, `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>helm-unittest coverage: %s</title>
+<style>%s</style>
+</head>
+<body>
+<h1>Coverage: %s</h1>
+<div class="subtitle">helm-unittest — generated report</div>
+`, html.EscapeString(cov.ChartName), htmlStyles, html.EscapeString(cov.ChartName))
+}
+
+func writeHTMLFoot(b *strings.Builder) {
+	b.WriteString("</body>\n</html>\n")
+}
+
+func writeHTMLSummary(b *strings.Builder, cov Coverage) {
+	b.WriteString(`<section class="summary">`)
+	statCard(b, "Actions", cov.Totals.Actions, false)
+	statCard(b, "Branches", cov.Totals.Branches, false)
+	statCard(b, "Loops", cov.Totals.Loops, true)
+	b.WriteString(`</section>`)
+}
+
+func statCard(b *strings.Builder, label string, s CountStat, showIters bool) {
+	pct := s.Pct()
+	pctClass := pctClass(pct)
+	pctText := "N/A"
+	subText := ""
+	if s.Total > 0 {
+		pctText = fmt.Sprintf("%.1f%%", pct)
+		subText = fmt.Sprintf("%d / %d covered", s.Covered, s.Total)
+	}
+	fmt.Fprintf(b,
+		`<div class="stat"><div class="label">%s</div><div class="value %s">%s</div><div class="sub">%s`,
+		html.EscapeString(label), pctClass, pctText, html.EscapeString(subText))
+	if showIters && s.Hits > 0 {
+		fmt.Fprintf(b, ` &middot; %d iters`, s.Hits)
+	}
+	b.WriteString(`</div></div>`)
+}
+
+func writeHTMLFileList(b *strings.Builder, cov Coverage) {
+	if len(cov.Files) == 0 {
+		b.WriteString(`<p>(no templates were instrumented)</p>`)
+		return
+	}
+	b.WriteString(`<table class="files"><thead><tr><th>File</th><th>Actions</th><th>Branches</th><th>Loops</th><th>Iters</th></tr></thead><tbody>`)
+	for _, f := range cov.Files {
+		fmt.Fprintf(b,
+			`<tr><td><a href="#%s">%s</a></td><td class="num">%s</td><td class="num">%s</td><td class="num">%s</td><td class="num">%s</td></tr>`,
+			htmlID(f.Name),
+			html.EscapeString(f.Name),
+			statCell(f.Actions, f.ParseError),
+			statCell(f.Branches, f.ParseError),
+			statCell(f.Loops, f.ParseError),
+			itersCell(f.Loops, f.ParseError),
+		)
+	}
+	b.WriteString(`</tbody></table>`)
+}
+
+func statCell(s CountStat, parseErr error) string {
+	if parseErr != nil {
+		return `<span class="pct-na">parse-error</span>`
+	}
+	if s.Total == 0 {
+		return `<span class="pct-na">&mdash;</span>`
+	}
+	return fmt.Sprintf(`<span class="%s">%d/%d (%.1f%%)</span>`,
+		pctClass(s.Pct()), s.Covered, s.Total, s.Pct())
+}
+
+func itersCell(loops CountStat, parseErr error) string {
+	if parseErr != nil || loops.Total == 0 || loops.Hits == 0 {
+		return `<span class="pct-na">&mdash;</span>`
+	}
+	return fmt.Sprintf(`%d`, loops.Hits)
+}
+
+func writeHTMLFileView(b *strings.Builder, f FileCoverage) {
+	fmt.Fprintf(b, `<details class="file" id="%s"><summary>%s<span class="badges">%s</span></summary>`,
+		htmlID(f.Name), html.EscapeString(f.Name), summaryBadges(f))
+
+	if f.ParseError != nil {
+		fmt.Fprintf(b, `<div class="parse-error">parse error: %s</div></details>`,
+			html.EscapeString(f.ParseError.Error()))
+		return
+	}
+
+	lineMap := map[int]LineCoverage{}
+	for _, ln := range f.Lines {
+		lineMap[ln.Line] = ln
+	}
+
+	b.WriteString(`<table class="source"><tbody>`)
+	lines := bytes.Split(f.Source, []byte("\n"))
+	for i, raw := range lines {
+		lineNum := i + 1
+		class := "neutral"
+		hits := "."
+		if lc, ok := lineMap[lineNum]; ok {
+			switch {
+			case lc.ProbesCovered == 0:
+				class = "missed"
+			case lc.ProbesCovered == lc.ProbesTotal:
+				class = "covered"
+			default:
+				class = "partial"
+			}
+			hits = fmt.Sprintf("%d", lc.Hits)
+		}
+		fmt.Fprintf(b,
+			`<tr class="%s"><td class="lineno">%d</td><td class="hits">%s</td><td class="code">%s</td></tr>`,
+			class, lineNum, hits, html.EscapeString(string(raw)))
+	}
+	b.WriteString(`</tbody></table></details>`)
+}
+
+func summaryBadges(f FileCoverage) string {
+	if f.ParseError != nil {
+		return `<span class="pct-low">parse error</span>`
+	}
+	parts := []string{}
+	if f.Actions.Total > 0 {
+		parts = append(parts, fmt.Sprintf(`A %d/%d`, f.Actions.Covered, f.Actions.Total))
+	}
+	if f.Branches.Total > 0 {
+		parts = append(parts, fmt.Sprintf(`B %d/%d`, f.Branches.Covered, f.Branches.Total))
+	}
+	if f.Loops.Total > 0 {
+		parts = append(parts, fmt.Sprintf(`L %d/%d`, f.Loops.Covered, f.Loops.Total))
+	}
+	return html.EscapeString(strings.Join(parts, " · "))
+}
+
+func pctClass(pct float64) string {
+	switch {
+	case pct < 0:
+		return "pct-na"
+	case pct >= 80:
+		return "pct-high"
+	case pct >= 50:
+		return "pct-mid"
+	default:
+		return "pct-low"
+	}
+}
+
+// htmlID maps a template path to an HTML anchor id. We strip characters that
+// confuse `#fragment` URLs (dots, slashes) while keeping the result readable.
+func htmlID(name string) string {
+	var b strings.Builder
+	b.WriteString("f-")
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}

--- a/pkg/unittest/coverage/html.go
+++ b/pkg/unittest/coverage/html.go
@@ -52,7 +52,7 @@ const htmlStyles = `
   table.files { width: 100%; border-collapse: collapse; margin-bottom: 32px; font-size: 13px; }
   .files th, .files td { text-align: left; padding: 6px 12px; border-bottom: 1px solid #d0d7de; }
   .files th { font-weight: 600; background: #f6f8fa; }
-  .files td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .files th.num, .files td.num { text-align: right; font-variant-numeric: tabular-nums; }
   .files a { color: #0969da; text-decoration: none; }
   .files a:hover { text-decoration: underline; }
   .pct-high { color: #1a7f37; }
@@ -138,7 +138,7 @@ func writeHTMLFileList(b *strings.Builder, cov Coverage) {
 		b.WriteString(`<p>(no templates were instrumented)</p>`)
 		return
 	}
-	b.WriteString(`<table class="files"><thead><tr><th>File</th><th>Actions</th><th>Branches</th><th>Loops</th><th>Iters</th></tr></thead><tbody>`)
+	b.WriteString(`<table class="files"><thead><tr><th>File</th><th class="num">Actions</th><th class="num">Branches</th><th class="num">Loops</th><th class="num">Iters</th></tr></thead><tbody>`)
 	for _, f := range cov.Files {
 		fmt.Fprintf(b,
 			`<tr><td><a href="#%s">%s</a></td><td class="num">%s</td><td class="num">%s</td><td class="num">%s</td><td class="num">%s</td></tr>`,

--- a/pkg/unittest/coverage/html.go
+++ b/pkg/unittest/coverage/html.go
@@ -76,6 +76,10 @@ const htmlStyles = `
   .source tr.partial .code { background: #fff8c5; }
   .source tr.neutral .code { background: transparent; }
   .parse-error { padding: 10px 14px; background: #ffebe9; color: #cf222e; }
+  .badge { display: inline-block; font-size: 11px; font-weight: 600; padding: 2px 8px;
+           border-radius: 10px; margin-left: 8px; vertical-align: middle; }
+  .badge-unused { background: #ffebe9; color: #cf222e; border: 1px solid #ffc1ba; }
+  .badge-used   { background: #ddf4e4; color: #1a7f37; border: 1px solid #b6e3c1; }
   @media (prefers-color-scheme: dark) {
     body { color: #c9d1d9; background: #0d1117; }
     .stat, .files th, details.file summary,
@@ -141,9 +145,10 @@ func writeHTMLFileList(b *strings.Builder, cov Coverage) {
 	b.WriteString(`<table class="files"><thead><tr><th>File</th><th class="num">Actions</th><th class="num">Branches</th><th class="num">Loops</th><th class="num">Iters</th></tr></thead><tbody>`)
 	for _, f := range cov.Files {
 		fmt.Fprintf(b,
-			`<tr><td><a href="#%s">%s</a></td><td class="num">%s</td><td class="num">%s</td><td class="num">%s</td><td class="num">%s</td></tr>`,
+			`<tr><td><a href="#%s">%s</a>%s</td><td class="num">%s</td><td class="num">%s</td><td class="num">%s</td><td class="num">%s</td></tr>`,
 			htmlID(f.Name),
 			html.EscapeString(f.Name),
+			renderedBadge(f),
 			statCell(f.Actions, f.ParseError),
 			statCell(f.Branches, f.ParseError),
 			statCell(f.Loops, f.ParseError),
@@ -224,7 +229,20 @@ func summaryBadges(f FileCoverage) string {
 	if f.Loops.Total > 0 {
 		parts = append(parts, fmt.Sprintf(`L %d/%d`, f.Loops.Covered, f.Loops.Total))
 	}
-	return html.EscapeString(strings.Join(parts, " · "))
+	return html.EscapeString(strings.Join(parts, " · ")) + renderedBadge(f)
+}
+
+// renderedBadge returns a small coloured pill marking the file as used or
+// unused. Parse-error files get no badge; they already render their own error
+// block, and the badge would just add visual noise.
+func renderedBadge(f FileCoverage) string {
+	if f.ParseError != nil {
+		return ""
+	}
+	if f.Rendered {
+		return `<span class="badge badge-used">used</span>`
+	}
+	return `<span class="badge badge-unused">unused</span>`
 }
 
 func pctClass(pct float64) string {

--- a/pkg/unittest/coverage/html_test.go
+++ b/pkg/unittest/coverage/html_test.go
@@ -15,14 +15,20 @@ func sampleHTMLCoverage() Coverage {
 	cov := Coverage{ChartName: "demo"}
 	cov.Files = []FileCoverage{
 		{
-			Name:    "demo/templates/cm.yaml",
-			Actions: CountStat{Covered: 1, Total: 2, Hits: 5},
+			Name:     "demo/templates/cm.yaml",
+			Rendered: true,
+			Actions:  CountStat{Covered: 1, Total: 2, Hits: 5},
 			Branches: CountStat{Covered: 1, Total: 2, Hits: 3},
-			Loops:   CountStat{Covered: 1, Total: 1, Hits: 4},
-			Source:  []byte("apiVersion: v1\nkind: ConfigMap\nname: {{ .Values.name }}\n"),
+			Loops:    CountStat{Covered: 1, Total: 1, Hits: 4},
+			Source:   []byte("apiVersion: v1\nkind: ConfigMap\nname: {{ .Values.name }}\n"),
 			Lines: []LineCoverage{
 				{Line: 3, Hits: 5, ProbesCovered: 1, ProbesTotal: 1},
 			},
+		},
+		{
+			Name:     "demo/templates/dead.yaml",
+			Rendered: false,
+			Source:   []byte("apiVersion: v1\nkind: ConfigMap\n"),
 		},
 		{
 			Name:       "demo/templates/broken.yaml",
@@ -71,6 +77,20 @@ func TestWriteHTML_StructureAndContent(t *testing.T) {
 	assert.Contains(t, contents, "synthetic parse failure")
 	// And no source table for the broken file.
 	assert.NotContains(t, contents, `<a href="#f-demo-templates-broken-yaml"><table`)
+
+	// Rendered/unused badges must appear on the right files.
+	assert.Contains(t, contents, `<span class="badge badge-used">used</span>`,
+		"cm.yaml should show a 'used' badge")
+	assert.Contains(t, contents, `<span class="badge badge-unused">unused</span>`,
+		"dead.yaml should show an 'unused' badge")
+	// Each badge should appear exactly twice (once in the file list row,
+	// once in the per-file <details> summary). Match the full element so the
+	// `.badge-used` / `.badge-unused` rules in the embedded stylesheet don't
+	// throw the count off.
+	usedCount := strings.Count(contents, `<span class="badge badge-used">used</span>`)
+	unusedCount := strings.Count(contents, `<span class="badge badge-unused">unused</span>`)
+	assert.Equal(t, 2, usedCount, "cm.yaml shows used badge twice (file list + summary)")
+	assert.Equal(t, 2, unusedCount, "dead.yaml shows unused badge twice")
 }
 
 func TestWriteReport_HTMLDispatch(t *testing.T) {

--- a/pkg/unittest/coverage/html_test.go
+++ b/pkg/unittest/coverage/html_test.go
@@ -1,0 +1,96 @@
+package coverage
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleHTMLCoverage() Coverage {
+	cov := Coverage{ChartName: "demo"}
+	cov.Files = []FileCoverage{
+		{
+			Name:    "demo/templates/cm.yaml",
+			Actions: CountStat{Covered: 1, Total: 2, Hits: 5},
+			Branches: CountStat{Covered: 1, Total: 2, Hits: 3},
+			Loops:   CountStat{Covered: 1, Total: 1, Hits: 4},
+			Source:  []byte("apiVersion: v1\nkind: ConfigMap\nname: {{ .Values.name }}\n"),
+			Lines: []LineCoverage{
+				{Line: 3, Hits: 5, ProbesCovered: 1, ProbesTotal: 1},
+			},
+		},
+		{
+			Name:       "demo/templates/broken.yaml",
+			ParseError: errors.New("synthetic parse failure"),
+			Source:     []byte("{{ if .Values.x"),
+		},
+	}
+	cov.Totals.Actions = CountStat{Covered: 1, Total: 2, Hits: 5}
+	cov.Totals.Branches = CountStat{Covered: 1, Total: 2, Hits: 3}
+	cov.Totals.Loops = CountStat{Covered: 1, Total: 1, Hits: 4}
+	return cov
+}
+
+func TestWriteHTML_StructureAndContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cov.html")
+	require.NoError(t, WriteHTML(path, sampleHTMLCoverage()))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	contents := string(data)
+
+	// Doctype + correct chart name in <title> and <h1>.
+	assert.True(t, strings.HasPrefix(contents, "<!doctype html>"), "missing doctype")
+	assert.Contains(t, contents, "<title>helm-unittest coverage: demo</title>")
+	assert.Contains(t, contents, "Coverage: demo")
+
+	// Summary cards for each dimension and the iterations badge.
+	assert.Contains(t, contents, ">Actions<")
+	assert.Contains(t, contents, ">Branches<")
+	assert.Contains(t, contents, ">Loops<")
+	assert.Contains(t, contents, "4 iters", "iteration count should appear on the loops stat card")
+
+	// File-list rows.
+	assert.Contains(t, contents, `<a href="#f-demo-templates-cm-yaml">demo/templates/cm.yaml</a>`)
+	assert.Contains(t, contents, `<a href="#f-demo-templates-broken-yaml">demo/templates/broken.yaml</a>`)
+
+	// Source lines: line 3 has a covered probe so should carry the covered class.
+	assert.Contains(t, contents, `<tr class="covered"><td class="lineno">3</td>`)
+	// Lines 1 and 2 have no probes — neutral.
+	assert.Contains(t, contents, `<tr class="neutral"><td class="lineno">1</td>`)
+
+	// Source content must be HTML-escaped so {{ and < survive intact.
+	assert.Contains(t, contents, "{{ .Values.name }}")
+	// Parse-error file gets a parse-error block, not a source table.
+	assert.Contains(t, contents, "synthetic parse failure")
+	// And no source table for the broken file.
+	assert.NotContains(t, contents, `<a href="#f-demo-templates-broken-yaml"><table`)
+}
+
+func TestWriteReport_HTMLDispatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.html")
+	require.NoError(t, WriteReport(path, FormatHTML, sampleHTMLCoverage()))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(data), "<!doctype html>"),
+		"WriteReport(..., \"html\", ...) should dispatch to WriteHTML")
+}
+
+func TestHTMLID_StableAndSafe(t *testing.T) {
+	cases := map[string]string{
+		"demo/templates/cm.yaml":         "f-demo-templates-cm-yaml",
+		"chart-with-dashes/templates/x":  "f-chart-with-dashes-templates-x",
+		"sub/_helpers.tpl":               "f-sub--helpers-tpl",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, htmlID(in), in)
+	}
+}

--- a/pkg/unittest/coverage/implicit_branch.go
+++ b/pkg/unittest/coverage/implicit_branch.go
@@ -1,0 +1,164 @@
+package coverage
+
+import (
+	"fmt"
+	"text/template/parse"
+)
+
+// maybeEmitImplicitBranch inspects an action node looking for an "implicit
+// branch" expressed inside its pipeline — currently `default` and `ternary`.
+// When one is found AND the input expression is a simple field / variable
+// reference (no nested function call that might run with side effects), the
+// instrumenter prepends a side-effect-free probe block that emits one of two
+// tokens depending on which path the helper would take.
+//
+// The probe block is emitted BEFORE the original action so the action's own
+// value flow is untouched; we only re-evaluate the input expression in a
+// boolean context. The "simple input" guard ensures that re-evaluation costs
+// nothing more than a map / field lookup.
+//
+// This is a best-effort enhancement: pipelines that don't fit the safe shape
+// (e.g. `{{ upper .X | default "y" }}`, `{{ default "y" (lookup ...) }}`) are
+// left alone and only the standard action probe is emitted.
+func (in *Instrumenter) maybeEmitImplicitBranch(action *parse.ActionNode, meta *TemplateMeta) {
+	if action == nil || action.Pipe == nil {
+		return
+	}
+	pipe := action.Pipe
+	if len(pipe.Cmds) == 0 {
+		return
+	}
+	last := pipe.Cmds[len(pipe.Cmds)-1]
+	if last == nil || len(last.Args) == 0 {
+		return
+	}
+	ident, ok := last.Args[0].(*parse.IdentifierNode)
+	if !ok {
+		return
+	}
+
+	switch ident.Ident {
+	case "default":
+		in.emitDefaultProbe(pipe, last, action.Pos, meta)
+	case "ternary":
+		in.emitTernaryProbe(pipe, last, action.Pos, meta)
+	}
+}
+
+// emitDefaultProbe handles both call shapes:
+//
+//	{{ default FALLBACK INPUT }}
+//	{{ INPUT | default FALLBACK }}
+//
+// The instrumented form prepends:
+//
+//	{{- if empty <INPUT> }}{{ "<token-fallback>" }}{{- else }}{{ "<token-primary>" }}{{- end -}}
+//	<original action>
+func (in *Instrumenter) emitDefaultProbe(pipe *parse.PipeNode, last *parse.CommandNode, pos parse.Pos, meta *TemplateMeta) {
+	input, ok := extractImplicitInput(pipe, last, 2) // default expects (id, fallback, input)
+	if !ok {
+		return
+	}
+	primary := in.tracker.registerProbe(Probe{
+		Kind: ProbeBranch, TemplateName: in.templateName,
+		Line: linecol(in.lineOffsets, pos, 0), Col: linecol(in.lineOffsets, pos, 1),
+		Label: "default-primary",
+	})
+	fallback := in.tracker.registerProbe(Probe{
+		Kind: ProbeBranch, TemplateName: in.templateName,
+		Line: linecol(in.lineOffsets, pos, 0), Col: linecol(in.lineOffsets, pos, 1),
+		Label: "default-fallback",
+	})
+	meta.ProbeIdxs = append(meta.ProbeIdxs, primary, fallback)
+
+	fmt.Fprintf(&in.out, `{{- if empty %s }}{{ "%s" }}{{- else }}{{ "%s" }}{{- end -}}`,
+		input, ProbeToken(fallback), ProbeToken(primary))
+}
+
+// emitTernaryProbe handles both call shapes:
+//
+//	{{ ternary TRUEVAL FALSEVAL COND }}
+//	{{ COND | ternary TRUEVAL FALSEVAL }}
+func (in *Instrumenter) emitTernaryProbe(pipe *parse.PipeNode, last *parse.CommandNode, pos parse.Pos, meta *TemplateMeta) {
+	cond, ok := extractImplicitInput(pipe, last, 3) // ternary expects (id, true, false, cond)
+	if !ok {
+		return
+	}
+	truth := in.tracker.registerProbe(Probe{
+		Kind: ProbeBranch, TemplateName: in.templateName,
+		Line: linecol(in.lineOffsets, pos, 0), Col: linecol(in.lineOffsets, pos, 1),
+		Label: "ternary-true",
+	})
+	falsy := in.tracker.registerProbe(Probe{
+		Kind: ProbeBranch, TemplateName: in.templateName,
+		Line: linecol(in.lineOffsets, pos, 0), Col: linecol(in.lineOffsets, pos, 1),
+		Label: "ternary-false",
+	})
+	meta.ProbeIdxs = append(meta.ProbeIdxs, truth, falsy)
+
+	fmt.Fprintf(&in.out, `{{- if %s }}{{ "%s" }}{{- else }}{{ "%s" }}{{- end -}}`,
+		cond, ProbeToken(truth), ProbeToken(falsy))
+}
+
+// extractImplicitInput pulls the "interesting" argument out of a default /
+// ternary call. callArgCount is the number of args the function takes in its
+// "no-pipe" form (e.g. default takes 2 args, so callArgCount is 2 + 1 for the
+// identifier itself when used directly; pass that final number here).
+//
+// Returns the source-text rendering of the input expression, parenthesised so
+// it slots into a surrounding `if` action safely. Returns ok=false when the
+// expression is not safe to re-evaluate (anything that's not a plain field /
+// variable / chain / dot reference).
+func extractImplicitInput(pipe *parse.PipeNode, last *parse.CommandNode, callArgCount int) (string, bool) {
+	// Form 1: direct call — `default FALLBACK INPUT` is one command with
+	// args [identifier, FALLBACK, INPUT]. The interesting arg is the LAST one.
+	if len(last.Args) == callArgCount+1 {
+		input := last.Args[callArgCount]
+		if !isSimpleAccess(input) {
+			return "", false
+		}
+		return "(" + input.String() + ")", true
+	}
+	// Form 2: pipe call — `INPUT | default FALLBACK` means `last` is
+	// `default FALLBACK` and the interesting input is the result of every
+	// command before it. We only handle the case where there's exactly one
+	// preceding command containing a single simple-access arg, so the
+	// re-evaluation cost is bounded.
+	if len(last.Args) == callArgCount && len(pipe.Cmds) == 2 {
+		prev := pipe.Cmds[0]
+		if len(prev.Args) != 1 {
+			return "", false
+		}
+		if !isSimpleAccess(prev.Args[0]) {
+			return "", false
+		}
+		return "(" + prev.Args[0].String() + ")", true
+	}
+	return "", false
+}
+
+// isSimpleAccess reports whether re-evaluating n in a side probe is safe.
+// "Safe" means: no function calls, no template invocations, no nested
+// pipelines. Plain field walks (.a.b.c), variables ($x), root context ({{.}})
+// and chains rooted in any of those are allowed.
+func isSimpleAccess(n parse.Node) bool {
+	switch v := n.(type) {
+	case *parse.FieldNode, *parse.VariableNode, *parse.DotNode:
+		return true
+	case *parse.ChainNode:
+		return isSimpleAccess(v.Node)
+	default:
+		return false
+	}
+}
+
+// linecol returns either the line (which=0) or column (which=1) for pos. It is
+// a small adapter around positionLineCol to make probe registration sites less
+// noisy.
+func linecol(offsets []int, pos parse.Pos, which int) int {
+	line, col := positionLineCol(offsets, int(pos))
+	if which == 0 {
+		return line
+	}
+	return col
+}

--- a/pkg/unittest/coverage/implicit_branch_test.go
+++ b/pkg/unittest/coverage/implicit_branch_test.go
@@ -1,0 +1,131 @@
+package coverage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v3chart "helm.sh/helm/v3/pkg/chart"
+	v3util "helm.sh/helm/v3/pkg/chartutil"
+	v3engine "helm.sh/helm/v3/pkg/engine"
+)
+
+func renderChart(t *testing.T, chart *v3chart.Chart, values map[string]any) map[string]string {
+	t.Helper()
+	vals, err := v3util.ToRenderValues(chart, values, v3util.ReleaseOptions{
+		Name: "rel", Namespace: "ns", IsInstall: true,
+	}, nil)
+	require.NoError(t, err)
+	out, err := v3engine.Render(chart, vals)
+	require.NoError(t, err)
+	return out
+}
+
+func TestImplicitBranch_DefaultPipeForm(t *testing.T) {
+	chart := buildTestChart("demo", map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name | default "fallback-name" }}
+`,
+	})
+	tracker := NewTracker(chart)
+
+	// First render: .Values.name is set → primary branch.
+	tracker.Absorb(renderChart(t, tracker.InstrumentedChart(), map[string]any{"name": "real"}))
+	// Second render: .Values.name empty → fallback branch.
+	tracker.Absorb(renderChart(t, tracker.InstrumentedChart(), map[string]any{}))
+
+	cov := tracker.Snapshot()
+	require.Len(t, cov.Files, 1)
+	f := cov.Files[0]
+
+	// One implicit pair (primary + fallback) should both be hit.
+	assert.Equal(t, 2, f.Branches.Covered)
+	assert.Equal(t, 2, f.Branches.Total)
+}
+
+func TestImplicitBranch_DefaultDirectForm(t *testing.T) {
+	chart := buildTestChart("demo", map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ default "fallback-name" .Values.name }}
+`,
+	})
+	tracker := NewTracker(chart)
+
+	tracker.Absorb(renderChart(t, tracker.InstrumentedChart(), map[string]any{}))
+
+	cov := tracker.Snapshot()
+	require.Len(t, cov.Files, 1)
+	f := cov.Files[0]
+	// Only the fallback was exercised: 1/2 implicit branches covered.
+	assert.Equal(t, 1, f.Branches.Covered)
+	assert.Equal(t, 2, f.Branches.Total)
+}
+
+func TestImplicitBranch_TernaryBothPaths(t *testing.T) {
+	chart := buildTestChart("demo", map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ ternary "yes" "no" .Values.flag }}
+`,
+	})
+	tracker := NewTracker(chart)
+
+	tracker.Absorb(renderChart(t, tracker.InstrumentedChart(), map[string]any{"flag": true}))
+	tracker.Absorb(renderChart(t, tracker.InstrumentedChart(), map[string]any{"flag": false}))
+
+	cov := tracker.Snapshot()
+	f := cov.Files[0]
+	assert.Equal(t, 2, f.Branches.Covered, "both ternary branches should be hit")
+	assert.Equal(t, 2, f.Branches.Total)
+}
+
+func TestImplicitBranch_SkipsUnsafePipelines(t *testing.T) {
+	chart := buildTestChart("demo", map[string]string{
+		// `upper .Values.name` is a function call in the prefix — we MUST
+		// NOT inject a side probe here, otherwise we'd run `upper` twice.
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ upper .Values.name | default "fallback" }}
+`,
+	})
+	tracker := NewTracker(chart)
+
+	cov := tracker.Snapshot()
+	f := cov.Files[0]
+	// Only the action probe exists; no implicit-branch pair was added.
+	assert.Equal(t, 0, f.Branches.Total, "unsafe pipeline must not be instrumented")
+	assert.Equal(t, 1, f.Actions.Total)
+}
+
+func TestLoops_IterationHitsTracked(t *testing.T) {
+	chart := buildTestChart("demo", map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+data:
+{{- range $i, $v := .Values.items }}
+  {{ $i }}: "{{ $v }}"
+{{- end }}
+`,
+	})
+	tracker := NewTracker(chart)
+
+	tracker.Absorb(renderChart(t, tracker.InstrumentedChart(), map[string]any{
+		"items": map[string]any{"a": "1", "b": "2", "c": "3"},
+	}))
+
+	cov := tracker.Snapshot()
+	f := cov.Files[0]
+	// 1 loop body, covered once (single loop probe), but Hits captures the
+	// real iteration count.
+	assert.Equal(t, 1, f.Loops.Total)
+	assert.Equal(t, 1, f.Loops.Covered)
+	assert.Equal(t, int64(3), f.Loops.Hits, "should record one hit per iteration")
+}

--- a/pkg/unittest/coverage/instrumenter.go
+++ b/pkg/unittest/coverage/instrumenter.go
@@ -1,0 +1,223 @@
+package coverage
+
+import (
+	"fmt"
+	"strings"
+	"text/template/parse"
+
+	"github.com/Masterminds/sprig/v3"
+)
+
+// tokenPrefix is the inline marker emitted by every probe. It is intentionally
+// unlikely to appear in real chart output and uses only word characters so it
+// survives most YAML quoting / escaping.
+const tokenPrefix = "__HELMCOV_PROBE_"
+const tokenSuffix = "__"
+
+// ProbeToken returns the inline marker text for a given global probe index.
+func ProbeToken(idx int) string {
+	return fmt.Sprintf("%s%d%s", tokenPrefix, idx, tokenSuffix)
+}
+
+// stubFuncs returns a func map that satisfies the text/template parser for
+// charts using Sprig and Helm-specific functions. The bodies are placeholders:
+// we never execute them. Helm's real engine runs the templates later with its
+// own function bindings, so what we provide here only needs to type-check the
+// parse tree.
+//
+// We seed the map from sprig.GenericFuncMap so any Sprig function the user's
+// chart references (append, replace, replace, etc.) is recognised, then layer
+// on the Helm engine extras that Sprig doesn't ship.
+func stubFuncs() map[string]any {
+	stub := func(_ ...any) any { return nil }
+	stubErr := func(_ ...any) (any, error) { return nil, nil }
+
+	m := map[string]any{}
+	for name := range sprig.GenericFuncMap() {
+		m[name] = stub
+	}
+	// Helm engine funcs that aren't in Sprig.
+	helmExtras := []string{
+		"include", "tpl", "fail",
+		"toYaml", "toYamlPretty", "toToml", "toJson",
+		"fromYaml", "fromYamlArray", "fromJson", "fromJsonArray",
+	}
+	for _, n := range helmExtras {
+		m[n] = stub
+	}
+	// Funcs that may be called in error-returning position.
+	m["required"] = stubErr
+	m["lookup"] = stubErr
+	return m
+}
+
+// Instrumenter walks a parsed template and rewrites it with probe tokens
+// inserted at every tracked construct. Probes are registered with the tracker
+// so each instrumented site gets a unique global index.
+type Instrumenter struct {
+	tracker      *Tracker
+	templateName string
+	out          strings.Builder
+	source       []byte
+	lineOffsets  []int // byte offset where each 1-based line starts
+}
+
+// Instrument parses data as a Go template and returns the instrumented source
+// plus per-template metadata. If the template fails to parse, the returned
+// bytes equal the input (no probes injected) and the meta carries ParseError.
+func (t *Tracker) Instrument(name string, data []byte) ([]byte, TemplateMeta) {
+	meta := TemplateMeta{Name: name, Source: data}
+
+	// SkipFuncCheck makes the parser tolerate any function reference, which
+	// is what we want: we never execute these templates ourselves, so the
+	// names need not resolve at parse time. Helm's real engine resolves them
+	// later, with its own funcMap, when it renders the instrumented chart.
+	trees := map[string]*parse.Tree{}
+	tree := parse.New(name, stubFuncs())
+	tree.Mode = parse.SkipFuncCheck
+	if _, err := tree.Parse(string(data), "{{", "}}", trees); err != nil {
+		meta.ParseError = err
+		return data, meta
+	}
+
+	ins := &Instrumenter{
+		tracker:      t,
+		templateName: name,
+		source:       data,
+		lineOffsets:  computeLineOffsets(data),
+	}
+
+	// The "main" tree carries the file's top-level content. Subtrees come from
+	// {{define "x"}}...{{end}} blocks and are keyed by their define name.
+	mainName := name
+	mainTree, hasMain := trees[mainName]
+	if hasMain {
+		ins.walkList(mainTree.Root, &meta)
+	}
+
+	// Emit each define block. Note that Helm-style _helpers.tpl files often
+	// contain ONLY define blocks, so the main tree's Root may be empty / just
+	// whitespace — but we still emit the define wrappers here so they remain
+	// callable from other templates.
+	for tname, tree := range trees {
+		if tname == mainName {
+			continue
+		}
+		ins.out.WriteString("\n{{- define \"")
+		ins.out.WriteString(tname)
+		ins.out.WriteString("\" -}}\n")
+		ins.walkList(tree.Root, &meta)
+		ins.out.WriteString("\n{{- end -}}\n")
+	}
+
+	return []byte(ins.out.String()), meta
+}
+
+func (in *Instrumenter) walkList(list *parse.ListNode, meta *TemplateMeta) {
+	if list == nil {
+		return
+	}
+	for _, node := range list.Nodes {
+		in.walk(node, meta)
+	}
+}
+
+func (in *Instrumenter) walk(node parse.Node, meta *TemplateMeta) {
+	switch n := node.(type) {
+	case *parse.ActionNode:
+		in.maybeEmitImplicitBranch(n, meta)
+		in.out.WriteString(n.String())
+		in.emitProbe(ProbeAction, n.Pos, "action", meta)
+	case *parse.TemplateNode:
+		in.out.WriteString(n.String())
+		in.emitProbe(ProbeAction, n.Pos, "template-call", meta)
+	case *parse.IfNode:
+		in.out.WriteString("{{ if ")
+		in.out.WriteString(n.Pipe.String())
+		in.out.WriteString(" }}")
+		in.emitProbe(ProbeBranch, n.Pos, "if", meta)
+		in.walkList(n.List, meta)
+		if n.ElseList != nil {
+			in.out.WriteString("{{ else }}")
+			in.emitProbe(ProbeBranch, n.Pos, "else", meta)
+			in.walkList(n.ElseList, meta)
+		}
+		in.out.WriteString("{{ end }}")
+	case *parse.WithNode:
+		in.out.WriteString("{{ with ")
+		in.out.WriteString(n.Pipe.String())
+		in.out.WriteString(" }}")
+		in.emitProbe(ProbeBranch, n.Pos, "with", meta)
+		in.walkList(n.List, meta)
+		if n.ElseList != nil {
+			in.out.WriteString("{{ else }}")
+			in.emitProbe(ProbeBranch, n.Pos, "with-else", meta)
+			in.walkList(n.ElseList, meta)
+		}
+		in.out.WriteString("{{ end }}")
+	case *parse.RangeNode:
+		in.out.WriteString("{{ range ")
+		in.out.WriteString(n.Pipe.String())
+		in.out.WriteString(" }}")
+		in.emitProbe(ProbeLoop, n.Pos, "range-body", meta)
+		in.walkList(n.List, meta)
+		if n.ElseList != nil {
+			in.out.WriteString("{{ else }}")
+			in.emitProbe(ProbeLoop, n.Pos, "range-else", meta)
+			in.walkList(n.ElseList, meta)
+		}
+		in.out.WriteString("{{ end }}")
+	case *parse.ListNode:
+		in.walkList(n, meta)
+	default:
+		// TextNode, CommentNode and anything else we don't instrument:
+		// emit verbatim.
+		in.out.WriteString(node.String())
+	}
+}
+
+func (in *Instrumenter) emitProbe(kind ProbeKind, pos parse.Pos, label string, meta *TemplateMeta) {
+	line, col := positionLineCol(in.lineOffsets, int(pos))
+	idx := in.tracker.registerProbe(Probe{
+		Kind:         kind,
+		TemplateName: in.templateName,
+		Line:         line,
+		Col:          col,
+		Label:        label,
+	})
+	meta.ProbeIdxs = append(meta.ProbeIdxs, idx)
+	// Wrap the token in a string-literal action so any surrounding template
+	// whitespace ("{{-" / "-}}") still applies cleanly; the literal is emitted
+	// verbatim into the output.
+	in.out.WriteString("{{ \"")
+	in.out.WriteString(ProbeToken(idx))
+	in.out.WriteString("\" }}")
+}
+
+// computeLineOffsets returns the byte offset of the start of each 1-based line.
+func computeLineOffsets(data []byte) []int {
+	offsets := []int{0}
+	for i, b := range data {
+		if b == '\n' {
+			offsets = append(offsets, i+1)
+		}
+	}
+	return offsets
+}
+
+// positionLineCol converts a byte offset to a 1-based (line, col).
+func positionLineCol(offsets []int, pos int) (int, int) {
+	if len(offsets) == 0 {
+		return 1, pos + 1
+	}
+	lo, hi := 0, len(offsets)-1
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if offsets[mid] <= pos {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return lo + 1, pos - offsets[lo] + 1
+}

--- a/pkg/unittest/coverage/instrumenter_test.go
+++ b/pkg/unittest/coverage/instrumenter_test.go
@@ -1,0 +1,126 @@
+package coverage
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstrument_RegistersProbesPerKind(t *testing.T) {
+	src := []byte(`
+apiVersion: v1
+kind: ConfigMap
+{{- if .Values.enabled }}
+data:
+  key: {{ .Values.key }}
+{{- else }}
+data: {}
+{{- end }}
+{{- range $i, $v := .Values.list }}
+  - item-{{ $i }}: {{ $v }}
+{{- end }}
+{{- with .Values.opt }}
+  optional: {{ .name }}
+{{- end }}
+`)
+
+	tr := NewTrackerForTest(t)
+	instr, meta := tr.Instrument("templates/cm.yaml", src)
+	require.NoError(t, meta.ParseError)
+
+	// The instrumenter should record at least: 2 branches (if/else),
+	// 1 loop body, 1 with branch, and several actions for variable refs.
+	var actions, branches, loops int
+	for _, idx := range meta.ProbeIdxs {
+		switch tr.probes[idx].Kind {
+		case ProbeAction:
+			actions++
+		case ProbeBranch:
+			branches++
+		case ProbeLoop:
+			loops++
+		}
+	}
+	assert.GreaterOrEqual(t, actions, 3, "should see multiple action probes (variable references)")
+	assert.Equal(t, 3, branches, "if + else + with should produce 3 branch probes")
+	assert.Equal(t, 1, loops, "range body should produce 1 loop probe")
+
+	// Every probe must reference our token format and the source must still
+	// parse as a valid Go template after instrumentation.
+	for _, idx := range meta.ProbeIdxs {
+		assert.Contains(t, string(instr), ProbeToken(idx))
+	}
+}
+
+func TestInstrument_PreservesDefineBlocks(t *testing.T) {
+	src := []byte(`{{- define "myapp.labels" -}}
+app: myapp
+{{- if .Values.extra }}
+extra: yes
+{{- end }}
+{{- end -}}`)
+
+	tr := NewTrackerForTest(t)
+	instr, meta := tr.Instrument("templates/_helpers.tpl", src)
+	require.NoError(t, meta.ParseError)
+
+	assert.Contains(t, string(instr), `{{- define "myapp.labels"`)
+	assert.Contains(t, string(instr), "{{- end -}}")
+	// At least one probe should have been emitted inside the define.
+	assert.NotEmpty(t, meta.ProbeIdxs)
+}
+
+func TestInstrument_TemplateWithParseError(t *testing.T) {
+	src := []byte(`{{ if .Values.x }}{{ /* missing end */ `)
+
+	tr := NewTrackerForTest(t)
+	out, meta := tr.Instrument("templates/broken.yaml", src)
+	assert.Error(t, meta.ParseError, "parse error should be recorded")
+	assert.Equal(t, src, out, "broken template should be returned unchanged")
+	assert.Empty(t, meta.ProbeIdxs)
+}
+
+func TestProbeToken_Format(t *testing.T) {
+	tok := ProbeToken(42)
+	re := regexp.MustCompile(regexp.QuoteMeta(tokenPrefix) + `\d+` + regexp.QuoteMeta(tokenSuffix))
+	assert.True(t, re.MatchString(tok), "token should match the documented format")
+	// Must NOT contain quotes or YAML-special characters that would break
+	// raw inclusion into the rendered output.
+	assert.False(t, strings.ContainsAny(tok, " \"\n\t:"))
+}
+
+func TestPositionLineCol(t *testing.T) {
+	data := []byte("ab\ncd\nef")
+	offsets := computeLineOffsets(data)
+
+	cases := []struct {
+		pos      int
+		wantLine int
+		wantCol  int
+	}{
+		{0, 1, 1},
+		{1, 1, 2},
+		{2, 1, 3}, // newline
+		{3, 2, 1},
+		{6, 3, 1},
+		{7, 3, 2},
+	}
+	for _, c := range cases {
+		l, col := positionLineCol(offsets, c.pos)
+		assert.Equal(t, c.wantLine, l, "line for pos %d", c.pos)
+		assert.Equal(t, c.wantCol, col, "col for pos %d", c.pos)
+	}
+}
+
+// NewTrackerForTest returns an empty tracker with no chart attached, suitable
+// for exercising Instrument in isolation.
+func NewTrackerForTest(t *testing.T) *Tracker {
+	t.Helper()
+	return &Tracker{
+		chartName:     "test",
+		templateMetas: map[string]TemplateMeta{},
+	}
+}

--- a/pkg/unittest/coverage/lcov.go
+++ b/pkg/unittest/coverage/lcov.go
@@ -1,0 +1,78 @@
+package coverage
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// WriteLCOV emits an LCOV-format coverage report at path. Coveralls, Codecov
+// and most IDE gutter integrations (VS Code "Coverage Gutters", JetBrains
+// "Run with Coverage" import, etc.) understand this format directly.
+//
+// Each template file becomes one LCOV record:
+//   - DA lines record per-line hit counts (sourced from action probes).
+//   - BRDA lines record each branch / loop probe individually.
+//   - LF/LH and BRF/BRH carry the summary totals.
+//
+// Templates that failed to parse are emitted as empty records so consumers
+// still see them in the file list.
+func WriteLCOV(path string, cov Coverage) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	w := bufio.NewWriter(f)
+	defer func() { _ = w.Flush() }()
+
+	for _, file := range cov.Files {
+		if _, err := fmt.Fprintln(w, "TN:helm-unittest"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "SF:%s\n", file.Name); err != nil {
+			return err
+		}
+
+		if file.ParseError != nil {
+			// Empty record so the file still appears in the file list.
+			if _, err := fmt.Fprintln(w, "LF:0\nLH:0\nBRF:0\nBRH:0\nend_of_record"); err != nil {
+				return err
+			}
+			continue
+		}
+
+		linesFound := 0
+		linesHit := 0
+		branchesFound := 0
+		branchesHit := 0
+		// BRDA blocks are grouped by source line; "block" is the line number,
+		// "branch" is the running index within that line.
+		for _, ln := range file.Lines {
+			if _, err := fmt.Fprintf(w, "DA:%d,%d\n", ln.Line, ln.Hits); err != nil {
+				return err
+			}
+			linesFound++
+			if ln.Hits > 0 {
+				linesHit++
+			}
+			for bi, br := range ln.Branches {
+				taken := "-"
+				if br.Hits > 0 {
+					taken = fmt.Sprintf("%d", br.Hits)
+					branchesHit++
+				}
+				if _, err := fmt.Fprintf(w, "BRDA:%d,%d,%d,%s\n", ln.Line, ln.Line, bi, taken); err != nil {
+					return err
+				}
+				branchesFound++
+			}
+		}
+
+		if _, err := fmt.Fprintf(w, "LF:%d\nLH:%d\nBRF:%d\nBRH:%d\nend_of_record\n", linesFound, linesHit, branchesFound, branchesHit); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/unittest/coverage/lcov.go
+++ b/pkg/unittest/coverage/lcov.go
@@ -34,6 +34,12 @@ func WriteLCOV(path string, cov Coverage) error {
 		if _, err := fmt.Fprintf(w, "SF:%s\n", file.Name); err != nil {
 			return err
 		}
+		// helm-unittest extension: emit the per-file Rendered status as a
+		// comment line. Standard LCOV parsers tolerate `#` comments; tools
+		// that recognise this prefix can surface unused templates.
+		if _, err := fmt.Fprintf(w, "# helm-unittest:rendered=%t\n", file.Rendered); err != nil {
+			return err
+		}
 
 		if file.ParseError != nil {
 			// Empty record so the file still appears in the file list.

--- a/pkg/unittest/coverage/lcov_test.go
+++ b/pkg/unittest/coverage/lcov_test.go
@@ -19,10 +19,17 @@ func TestWriteLCOV_RecordsAndCounters(t *testing.T) {
 	require.NoError(t, err)
 	contents := string(data)
 
-	// Two records: one real, one empty for the parse-error file.
-	assert.Equal(t, 2, strings.Count(contents, "end_of_record"))
+	// Three records: cm.yaml (rendered), dead.yaml (unrendered), broken.yaml (parse-error).
+	assert.Equal(t, 3, strings.Count(contents, "end_of_record"))
 	assert.Contains(t, contents, "SF:demo/templates/cm.yaml")
+	assert.Contains(t, contents, "SF:demo/templates/dead.yaml")
 	assert.Contains(t, contents, "SF:demo/templates/broken.yaml")
+
+	// helm-unittest extension comment lines should encode per-file Rendered status.
+	assert.Contains(t, contents, "# helm-unittest:rendered=true",
+		"cm.yaml should be flagged as rendered")
+	assert.Contains(t, contents, "# helm-unittest:rendered=false",
+		"dead.yaml / broken.yaml should be flagged as unrendered")
 
 	// Per-line DA lines must be present for every Lines entry on the real file.
 	assert.Contains(t, contents, "DA:4,2")

--- a/pkg/unittest/coverage/lcov_test.go
+++ b/pkg/unittest/coverage/lcov_test.go
@@ -1,0 +1,60 @@
+package coverage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteLCOV_RecordsAndCounters(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lcov.info")
+	require.NoError(t, WriteLCOV(path, sampleCoverage()))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	contents := string(data)
+
+	// Two records: one real, one empty for the parse-error file.
+	assert.Equal(t, 2, strings.Count(contents, "end_of_record"))
+	assert.Contains(t, contents, "SF:demo/templates/cm.yaml")
+	assert.Contains(t, contents, "SF:demo/templates/broken.yaml")
+
+	// Per-line DA lines must be present for every Lines entry on the real file.
+	assert.Contains(t, contents, "DA:4,2")
+	assert.Contains(t, contents, "DA:6,0")
+	assert.Contains(t, contents, "DA:9,0")
+
+	// Branch records: line 6 has two branches (if covered=0, else covered=2),
+	// line 9 has one (range body, uncovered).
+	assert.Contains(t, contents, "BRDA:6,6,0,-")    // if: uncovered
+	assert.Contains(t, contents, "BRDA:6,6,1,2")    // else: hit 2x
+	assert.Contains(t, contents, "BRDA:9,9,0,-")    // range body: uncovered
+
+	// Summary lines for the real record.
+	assert.Contains(t, contents, "LF:3")
+	assert.Contains(t, contents, "LH:1") // only line 4 had hits
+	assert.Contains(t, contents, "BRF:3")
+	assert.Contains(t, contents, "BRH:1") // only the else branch ran
+}
+
+func TestWriteReport_UnknownFormat(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out")
+	err := WriteReport(path, "nope", sampleCoverage())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported coverage format")
+}
+
+func TestWriteReport_DefaultIsJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.json")
+	require.NoError(t, WriteReport(path, "", sampleCoverage()))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(string(data)), "{"), "default writer should emit JSON")
+}

--- a/pkg/unittest/coverage/multi_format_test.go
+++ b/pkg/unittest/coverage/multi_format_test.go
@@ -38,12 +38,37 @@ func TestParseFormats(t *testing.T) {
 }
 
 func TestResolveOutputPaths_SingleFormatVerbatim(t *testing.T) {
-	// One format → user's path is used exactly as given. This preserves
-	// the long-standing single-format behaviour.
+	// One format → user's path is used exactly as given when it already
+	// carries an extension. Preserves the long-standing single-format
+	// behaviour for callers that have always passed a full filename.
 	got := ResolveOutputPaths("coverage.xml", []string{FormatCobertura})
 	require.Len(t, got, 1)
 	assert.Equal(t, "coverage.xml", got[0].Path)
 	assert.Equal(t, FormatCobertura, got[0].Format)
+}
+
+func TestResolveOutputPaths_SingleFormatAppendsExtensionWhenMissing(t *testing.T) {
+	// Extension-less path under a single format gets the format's
+	// conventional extension. Avoids the footgun where the user writes
+	// `--coverage-file ./reports/cov --coverage-format cobertura` and ends
+	// up with an extension-less file no tool can recognise.
+	cases := []struct {
+		in       string
+		format   string
+		wantPath string
+	}{
+		{"coverage", FormatJSON, "coverage.json"},
+		{"./reports/cov", FormatCobertura, "./reports/cov.xml"},
+		{"out", FormatLCOV, "out.info"},
+		{"report", FormatHTML, "report.html"},
+		// User-provided extension wins, even when it doesn't match the format.
+		{"coverage.report", FormatJSON, "coverage.report"},
+	}
+	for _, c := range cases {
+		got := ResolveOutputPaths(c.in, []string{c.format})
+		require.Len(t, got, 1, c.in)
+		assert.Equal(t, c.wantPath, got[0].Path, "input %q + %s", c.in, c.format)
+	}
 }
 
 func TestResolveOutputPaths_MultiFormatStem(t *testing.T) {

--- a/pkg/unittest/coverage/multi_format_test.go
+++ b/pkg/unittest/coverage/multi_format_test.go
@@ -1,0 +1,119 @@
+package coverage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFormats(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+		err  bool
+	}{
+		{in: "", want: []string{FormatJSON}},
+		{in: "   ", want: []string{FormatJSON}},
+		{in: "json", want: []string{FormatJSON}},
+		{in: "cobertura,lcov,html", want: []string{FormatCobertura, FormatLCOV, FormatHTML}},
+		{in: "cobertura , lcov , html", want: []string{FormatCobertura, FormatLCOV, FormatHTML}, // whitespace tolerated
+		},
+		{in: "html,html,html", want: []string{FormatHTML}}, // duplicates collapsed
+		{in: "json,nope", err: true},
+		{in: ",,,", err: true}, // nothing usable
+	}
+	for _, c := range cases {
+		got, err := ParseFormats(c.in)
+		if c.err {
+			require.Error(t, err, "input %q should fail", c.in)
+			continue
+		}
+		require.NoError(t, err, "input %q", c.in)
+		assert.Equal(t, c.want, got, "input %q", c.in)
+	}
+}
+
+func TestResolveOutputPaths_SingleFormatVerbatim(t *testing.T) {
+	// One format → user's path is used exactly as given. This preserves
+	// the long-standing single-format behaviour.
+	got := ResolveOutputPaths("coverage.xml", []string{FormatCobertura})
+	require.Len(t, got, 1)
+	assert.Equal(t, "coverage.xml", got[0].Path)
+	assert.Equal(t, FormatCobertura, got[0].Format)
+}
+
+func TestResolveOutputPaths_MultiFormatStem(t *testing.T) {
+	// Multiple formats → path is a stem; each format gets its own extension.
+	got := ResolveOutputPaths("./reports/cov", []string{FormatCobertura, FormatLCOV, FormatHTML, FormatJSON})
+	want := map[string]string{
+		"./reports/cov.xml":   FormatCobertura,
+		"./reports/cov.info":  FormatLCOV,
+		"./reports/cov.html":  FormatHTML,
+		"./reports/cov.json":  FormatJSON,
+	}
+	for _, target := range got {
+		assert.Equal(t, want[target.Path], target.Format, target.Path)
+	}
+	assert.Len(t, got, 4)
+}
+
+func TestResolveOutputPaths_MultiFormatStripsKnownExtension(t *testing.T) {
+	// If the user accidentally passes a path with a known extension, we
+	// strip it so we don't end up writing `coverage.xml.xml`.
+	got := ResolveOutputPaths("coverage.xml", []string{FormatCobertura, FormatHTML})
+	paths := []string{got[0].Path, got[1].Path}
+	assert.Contains(t, paths, "coverage.xml")
+	assert.Contains(t, paths, "coverage.html")
+}
+
+func TestResolveOutputPaths_MultiFormatUnknownExtensionKept(t *testing.T) {
+	// Unknown extensions are left alone (treated as part of the stem).
+	got := ResolveOutputPaths("custom.cov", []string{FormatCobertura, FormatLCOV})
+	paths := []string{got[0].Path, got[1].Path}
+	assert.Contains(t, paths, "custom.cov.xml")
+	assert.Contains(t, paths, "custom.cov.info")
+}
+
+func TestFormatExt(t *testing.T) {
+	assert.Equal(t, ".json", FormatExt(FormatJSON))
+	assert.Equal(t, ".xml", FormatExt(FormatCobertura))
+	assert.Equal(t, ".info", FormatExt(FormatLCOV))
+	assert.Equal(t, ".html", FormatExt(FormatHTML))
+	assert.Equal(t, "", FormatExt("bogus"))
+}
+
+// TestWriteReport_AcceptsAllResolvedFormats verifies the end-to-end multi-
+// format flow: ResolveOutputPaths produces targets, WriteReport dispatches
+// each one, and the resulting files have the right magic.
+func TestWriteReport_AcceptsAllResolvedFormats(t *testing.T) {
+	dir := t.TempDir()
+	stem := filepath.Join(dir, "cov")
+
+	formats, err := ParseFormats("cobertura,lcov,html,json")
+	require.NoError(t, err)
+
+	for _, target := range ResolveOutputPaths(stem, formats) {
+		require.NoError(t, WriteReport(target.Path, target.Format, sampleCoverage()),
+			"writing %s to %s", target.Format, target.Path)
+	}
+
+	xml, err := os.ReadFile(stem + ".xml")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(xml), "<?xml"), "cobertura output should be XML")
+
+	info, err := os.ReadFile(stem + ".info")
+	require.NoError(t, err)
+	assert.Contains(t, string(info), "end_of_record", "lcov output should have records")
+
+	html, err := os.ReadFile(stem + ".html")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(html), "<!doctype html>"), "html output should look like HTML")
+
+	js, err := os.ReadFile(stem + ".json")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(string(js)), "{"), "json output should look like JSON")
+}

--- a/pkg/unittest/coverage/reporter.go
+++ b/pkg/unittest/coverage/reporter.go
@@ -221,6 +221,94 @@ const (
 	FormatHTML      = "html"
 )
 
+// FormatExt returns the conventional file extension for a coverage format
+// (including the leading dot). Used to derive per-format filenames when a
+// single --coverage-file stem is shared across multiple formats. Returns ""
+// for unknown formats.
+func FormatExt(format string) string {
+	switch format {
+	case FormatJSON:
+		return ".json"
+	case FormatCobertura:
+		return ".xml"
+	case FormatLCOV:
+		return ".info"
+	case FormatHTML:
+		return ".html"
+	default:
+		return ""
+	}
+}
+
+// ParseFormats parses a comma-separated --coverage-format value, trimming
+// whitespace around each entry. An empty string defaults to ["json"]. Any
+// unrecognised format produces an error so misspellings fail loudly instead
+// of being silently dropped.
+func ParseFormats(s string) ([]string, error) {
+	if strings.TrimSpace(s) == "" {
+		return []string{FormatJSON}, nil
+	}
+	known := map[string]bool{
+		FormatJSON: true, FormatCobertura: true, FormatLCOV: true, FormatHTML: true,
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	seen := map[string]bool{}
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if !known[p] {
+			return nil, fmt.Errorf("unsupported coverage format %q (want json, cobertura, lcov, or html)", p)
+		}
+		if seen[p] {
+			continue // ignore duplicates rather than writing the same file twice
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--coverage-format must list at least one format")
+	}
+	return out, nil
+}
+
+// FileTarget pairs an output path with the format that should be written
+// there. Returned by ResolveOutputPaths.
+type FileTarget struct {
+	Path   string
+	Format string
+}
+
+// knownExtensions lists every extension ResolveOutputPaths is willing to strip
+// when treating a user-provided --coverage-file as a stem.
+var knownExtensions = []string{".json", ".xml", ".info", ".html"}
+
+// ResolveOutputPaths maps the user's --coverage-file value to a list of
+// concrete (path, format) targets. For a single format the path is used
+// verbatim — existing behaviour. For multiple formats the path is treated as
+// a stem: a trailing extension matching one of our known formats is stripped
+// (so `coverage.xml` becomes `coverage`), then `FormatExt(f)` is appended for
+// each requested format.
+func ResolveOutputPaths(file string, formats []string) []FileTarget {
+	if len(formats) == 1 {
+		return []FileTarget{{Path: file, Format: formats[0]}}
+	}
+	stem := file
+	for _, ext := range knownExtensions {
+		if strings.HasSuffix(stem, ext) {
+			stem = strings.TrimSuffix(stem, ext)
+			break
+		}
+	}
+	out := make([]FileTarget, 0, len(formats))
+	for _, f := range formats {
+		out = append(out, FileTarget{Path: stem + FormatExt(f), Format: f})
+	}
+	return out
+}
+
 // WriteReport dispatches to the writer for the requested format. An unknown
 // format returns an error rather than silently picking a default — callers are
 // expected to validate user input before calling.

--- a/pkg/unittest/coverage/reporter.go
+++ b/pkg/unittest/coverage/reporter.go
@@ -196,6 +196,7 @@ const (
 	FormatJSON      = "json"
 	FormatCobertura = "cobertura"
 	FormatLCOV      = "lcov"
+	FormatHTML      = "html"
 )
 
 // WriteReport dispatches to the writer for the requested format. An unknown
@@ -209,8 +210,10 @@ func WriteReport(path, format string, cov Coverage) error {
 		return WriteCobertura(path, cov)
 	case FormatLCOV:
 		return WriteLCOV(path, cov)
+	case FormatHTML:
+		return WriteHTML(path, cov)
 	default:
-		return fmt.Errorf("unsupported coverage format %q (want json, cobertura, or lcov)", format)
+		return fmt.Errorf("unsupported coverage format %q (want json, cobertura, lcov, or html)", format)
 	}
 }
 

--- a/pkg/unittest/coverage/reporter.go
+++ b/pkg/unittest/coverage/reporter.go
@@ -32,13 +32,18 @@ func RenderConsole(p *printer.Printer, cov Coverage) {
 	}
 
 	rows := make([][]string, 0, len(cov.Files)+2)
-	rows = append(rows, []string{"File", "Actions", "Branches", "Loops"})
+	rows = append(rows, []string{"File", "Actions", "Branches", "Loops", "Used"})
+	usedFiles := 0
 	for _, f := range cov.Files {
+		if f.Rendered {
+			usedFiles++
+		}
 		rows = append(rows, []string{
 			f.Name,
 			formatStat(p, f.Actions, f.ParseError),
 			formatStat(p, f.Branches, f.ParseError),
 			formatLoopStat(p, f.Loops, f.ParseError),
+			formatUsed(p, f),
 		})
 	}
 	rows = append(rows, []string{
@@ -46,6 +51,7 @@ func RenderConsole(p *printer.Printer, cov Coverage) {
 		formatStat(p, cov.Totals.Actions, nil),
 		formatStat(p, cov.Totals.Branches, nil),
 		formatLoopStat(p, cov.Totals.Loops, nil),
+		fmt.Sprintf("%d/%d", usedFiles, len(cov.Files)),
 	})
 
 	printTable(w, rows)
@@ -103,6 +109,22 @@ func formatLoopStat(p *printer.Printer, s CountStat, parseErr error) string {
 		plain = fmt.Sprintf("%s, %d iters", plain, s.Hits)
 	}
 	return colorizeByPct(p, plain, s.Pct())
+}
+
+func formatUsed(p *printer.Printer, f FileCoverage) string {
+	if f.ParseError != nil {
+		return "parse-error"
+	}
+	if f.Rendered {
+		if p != nil {
+			return p.Success("%s", "yes")
+		}
+		return "yes"
+	}
+	if p != nil {
+		return p.Danger("%s", "no")
+	}
+	return "no"
 }
 
 func colorizeByPct(p *printer.Printer, text string, pct float64) string {
@@ -242,6 +264,7 @@ type jsonStat struct {
 type jsonFile struct {
 	Name        string   `json:"name"`
 	ParseError  string   `json:"parseError,omitempty"`
+	Rendered    bool     `json:"rendered"`
 	Actions     jsonStat `json:"actions"`
 	Branches    jsonStat `json:"branches"`
 	Loops       jsonStat `json:"loops"`
@@ -263,6 +286,7 @@ func toJSONReport(cov Coverage) jsonReport {
 	for _, f := range cov.Files {
 		entry := jsonFile{
 			Name:        f.Name,
+			Rendered:    f.Rendered,
 			Actions:     toJSONStat(f.Actions),
 			Branches:    toJSONStat(f.Branches),
 			Loops:       toJSONStat(f.Loops),

--- a/pkg/unittest/coverage/reporter.go
+++ b/pkg/unittest/coverage/reporter.go
@@ -1,0 +1,285 @@
+package coverage
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/printer"
+)
+
+// RenderConsole prints a human-friendly per-template coverage table to the
+// provided printer. If p is nil, plain text is written to os.Stdout.
+func RenderConsole(p *printer.Printer, cov Coverage) {
+	w := io.Writer(os.Stdout)
+	if p != nil {
+		w = p.Writer
+	}
+
+	fmt.Fprintln(w)
+	header := fmt.Sprintf("### Coverage [ %s ]", cov.ChartName)
+	if p != nil {
+		header = fmt.Sprintf("### Coverage [ %s ]", p.Highlight("%s", cov.ChartName))
+	}
+	fmt.Fprintln(w, header)
+	fmt.Fprintln(w)
+
+	if len(cov.Files) == 0 {
+		fmt.Fprintln(w, "(no templates were instrumented)")
+		return
+	}
+
+	rows := make([][]string, 0, len(cov.Files)+2)
+	rows = append(rows, []string{"File", "Actions", "Branches", "Loops"})
+	for _, f := range cov.Files {
+		rows = append(rows, []string{
+			f.Name,
+			formatStat(p, f.Actions, f.ParseError),
+			formatStat(p, f.Branches, f.ParseError),
+			formatLoopStat(p, f.Loops, f.ParseError),
+		})
+	}
+	rows = append(rows, []string{
+		"ALL FILES",
+		formatStat(p, cov.Totals.Actions, nil),
+		formatStat(p, cov.Totals.Branches, nil),
+		formatLoopStat(p, cov.Totals.Loops, nil),
+	})
+
+	printTable(w, rows)
+
+	// Surface parse failures and uncovered lines as a follow-up block.
+	var parseErrs []FileCoverage
+	var uncovered []FileCoverage
+	for _, f := range cov.Files {
+		if f.ParseError != nil {
+			parseErrs = append(parseErrs, f)
+		} else if len(f.MissedLines) > 0 {
+			uncovered = append(uncovered, f)
+		}
+	}
+	if len(parseErrs) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Templates skipped (parse error):")
+		for _, f := range parseErrs {
+			fmt.Fprintf(w, "  - %s: %v\n", f.Name, f.ParseError)
+		}
+	}
+	if len(uncovered) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Uncovered lines:")
+		for _, f := range uncovered {
+			fmt.Fprintf(w, "  - %s: %s\n", f.Name, joinInts(f.MissedLines))
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+func formatStat(p *printer.Printer, s CountStat, parseErr error) string {
+	if parseErr != nil {
+		return "parse-error"
+	}
+	if s.Total == 0 {
+		return "-"
+	}
+	plain := fmt.Sprintf("%d/%d (%.1f%%)", s.Covered, s.Total, s.Pct())
+	return colorizeByPct(p, plain, s.Pct())
+}
+
+// formatLoopStat augments the standard stat string with the total iteration
+// count, so the table conveys "ran N times" alongside "X of Y loop bodies
+// were entered". Iterations only show when at least one loop ran.
+func formatLoopStat(p *printer.Printer, s CountStat, parseErr error) string {
+	if parseErr != nil {
+		return "parse-error"
+	}
+	if s.Total == 0 {
+		return "-"
+	}
+	plain := fmt.Sprintf("%d/%d (%.1f%%)", s.Covered, s.Total, s.Pct())
+	if s.Hits > 0 {
+		plain = fmt.Sprintf("%s, %d iters", plain, s.Hits)
+	}
+	return colorizeByPct(p, plain, s.Pct())
+}
+
+func colorizeByPct(p *printer.Printer, text string, pct float64) string {
+	if p == nil {
+		return text
+	}
+	switch {
+	case pct >= 80:
+		return p.Success("%s", text)
+	case pct >= 50:
+		return p.Warning("%s", text)
+	default:
+		return p.Danger("%s", text)
+	}
+}
+
+// printTable renders a left-aligned table. We avoid pulling a third-party
+// table library to keep dependency surface minimal — the layout is simple
+// enough to compute inline. Column widths are computed from visible-rune
+// length so embedded ANSI color escapes do not throw off alignment.
+func printTable(w io.Writer, rows [][]string) {
+	if len(rows) == 0 {
+		return
+	}
+	cols := len(rows[0])
+	widths := make([]int, cols)
+	for _, r := range rows {
+		for i := 0; i < cols && i < len(r); i++ {
+			if l := visibleLen(r[i]); l > widths[i] {
+				widths[i] = l
+			}
+		}
+	}
+	for ri, r := range rows {
+		var sb strings.Builder
+		for i := 0; i < cols; i++ {
+			cell := ""
+			if i < len(r) {
+				cell = r[i]
+			}
+			sb.WriteString(cell)
+			sb.WriteString(strings.Repeat(" ", widths[i]-visibleLen(cell)))
+			if i < cols-1 {
+				sb.WriteString("  ")
+			}
+		}
+		fmt.Fprintln(w, sb.String())
+		if ri == 0 {
+			// header separator
+			var sep strings.Builder
+			for i := 0; i < cols; i++ {
+				sep.WriteString(strings.Repeat("-", widths[i]))
+				if i < cols-1 {
+					sep.WriteString("  ")
+				}
+			}
+			fmt.Fprintln(w, sep.String())
+		}
+	}
+}
+
+// visibleLen returns the rune length of s with ANSI color escapes removed.
+func visibleLen(s string) int {
+	out := 0
+	inEsc := false
+	for _, r := range s {
+		switch {
+		case r == 0x1b:
+			inEsc = true
+		case inEsc && r == 'm':
+			inEsc = false
+		case inEsc:
+			// skip
+		default:
+			out++
+		}
+	}
+	return out
+}
+
+func joinInts(xs []int) string {
+	parts := make([]string, len(xs))
+	for i, x := range xs {
+		parts[i] = fmt.Sprintf("%d", x)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// Supported file-output formats for --coverage-format.
+const (
+	FormatJSON      = "json"
+	FormatCobertura = "cobertura"
+	FormatLCOV      = "lcov"
+)
+
+// WriteReport dispatches to the writer for the requested format. An unknown
+// format returns an error rather than silently picking a default — callers are
+// expected to validate user input before calling.
+func WriteReport(path, format string, cov Coverage) error {
+	switch format {
+	case "", FormatJSON:
+		return WriteJSON(path, cov)
+	case FormatCobertura:
+		return WriteCobertura(path, cov)
+	case FormatLCOV:
+		return WriteLCOV(path, cov)
+	default:
+		return fmt.Errorf("unsupported coverage format %q (want json, cobertura, or lcov)", format)
+	}
+}
+
+// WriteJSON writes a stable JSON document to path describing per-file and
+// total coverage. The schema is intended for CI consumption and is documented
+// in DOCUMENT.md.
+func WriteJSON(path string, cov Coverage) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(toJSONReport(cov))
+}
+
+type jsonStat struct {
+	Covered int     `json:"covered"`
+	Total   int     `json:"total"`
+	Pct     float64 `json:"pct"`
+	Hits    int64   `json:"hits"`
+}
+
+type jsonFile struct {
+	Name        string   `json:"name"`
+	ParseError  string   `json:"parseError,omitempty"`
+	Actions     jsonStat `json:"actions"`
+	Branches    jsonStat `json:"branches"`
+	Loops       jsonStat `json:"loops"`
+	MissedLines []int    `json:"missedLines,omitempty"`
+}
+
+type jsonReport struct {
+	Chart  string   `json:"chart"`
+	Files  []jsonFile `json:"files"`
+	Totals struct {
+		Actions  jsonStat `json:"actions"`
+		Branches jsonStat `json:"branches"`
+		Loops    jsonStat `json:"loops"`
+	} `json:"totals"`
+}
+
+func toJSONReport(cov Coverage) jsonReport {
+	r := jsonReport{Chart: cov.ChartName}
+	for _, f := range cov.Files {
+		entry := jsonFile{
+			Name:        f.Name,
+			Actions:     toJSONStat(f.Actions),
+			Branches:    toJSONStat(f.Branches),
+			Loops:       toJSONStat(f.Loops),
+			MissedLines: f.MissedLines,
+		}
+		if f.ParseError != nil {
+			entry.ParseError = f.ParseError.Error()
+		}
+		r.Files = append(r.Files, entry)
+	}
+	r.Totals.Actions = toJSONStat(cov.Totals.Actions)
+	r.Totals.Branches = toJSONStat(cov.Totals.Branches)
+	r.Totals.Loops = toJSONStat(cov.Totals.Loops)
+	return r
+}
+
+func toJSONStat(s CountStat) jsonStat {
+	pct := s.Pct()
+	if pct < 0 {
+		pct = 0
+	}
+	return jsonStat{Covered: s.Covered, Total: s.Total, Pct: pct, Hits: s.Hits}
+}

--- a/pkg/unittest/coverage/reporter.go
+++ b/pkg/unittest/coverage/reporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/printer"
@@ -286,14 +287,23 @@ type FileTarget struct {
 var knownExtensions = []string{".json", ".xml", ".info", ".html"}
 
 // ResolveOutputPaths maps the user's --coverage-file value to a list of
-// concrete (path, format) targets. For a single format the path is used
-// verbatim — existing behaviour. For multiple formats the path is treated as
-// a stem: a trailing extension matching one of our known formats is stripped
-// (so `coverage.xml` becomes `coverage`), then `FormatExt(f)` is appended for
+// concrete (path, format) targets.
+//
+// For a single format, the path is used as-is when it already carries an
+// extension; an extension-less path (e.g. `./reports/cov`) gets the format's
+// conventional extension appended so the file is written somewhere sensible.
+//
+// For multiple formats, the path is always treated as a stem: a trailing
+// extension matching one of our known formats is stripped first (so
+// `coverage.xml` becomes `coverage`), then `FormatExt(f)` is appended for
 // each requested format.
 func ResolveOutputPaths(file string, formats []string) []FileTarget {
 	if len(formats) == 1 {
-		return []FileTarget{{Path: file, Format: formats[0]}}
+		path := file
+		if filepath.Ext(path) == "" {
+			path += FormatExt(formats[0])
+		}
+		return []FileTarget{{Path: path, Format: formats[0]}}
 	}
 	stem := file
 	for _, ext := range knownExtensions {

--- a/pkg/unittest/coverage/tracker.go
+++ b/pkg/unittest/coverage/tracker.go
@@ -1,0 +1,278 @@
+package coverage
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	v3chart "helm.sh/helm/v3/pkg/chart"
+)
+
+const logField = "coverage"
+
+// Tracker instruments a chart's templates and aggregates probe hits across
+// every render performed against the instrumented chart.
+//
+// The tracker is goroutine-safe: probes are registered once at chart setup
+// time, and Absorb may be called concurrently from multiple test jobs.
+type Tracker struct {
+	chartName string
+
+	mu     sync.Mutex
+	probes []Probe
+	hits   []int64
+
+	// templateMetas keeps per-template information (probe indexes, parse
+	// errors). Keys are the chart-rooted template paths used in chart.File.Name
+	// (e.g. "templates/deployment.yaml"). For subchart templates we use the
+	// subchart-relative path to avoid collisions across charts; sub-chart files
+	// always retain their own chart-root path.
+	templateMetas map[string]TemplateMeta
+	// templateOrder preserves the insertion order so reports list files in a
+	// stable, source-like order.
+	templateOrder []string
+
+	// instrumentedChart is a deep clone of the input chart whose Templates
+	// (and all subcharts' Templates) have been swapped for instrumented bytes.
+	// We retain it so test jobs can reuse it without re-instrumenting per run.
+	instrumentedChart *v3chart.Chart
+}
+
+// NewTracker constructs a tracker by instrumenting every template in the chart
+// and its dependency subcharts. Templates that fail to parse are kept verbatim
+// in the cloned chart but recorded with a ParseError in their metadata so the
+// final report can surface them.
+//
+// The returned tracker owns its own deep copy of the chart; the input is not
+// modified.
+func NewTracker(chart *v3chart.Chart) *Tracker {
+	t := &Tracker{
+		chartName:     chart.Name(),
+		templateMetas: map[string]TemplateMeta{},
+	}
+	t.instrumentedChart = t.deepCopyAndInstrument(chart, chart.Name())
+	return t
+}
+
+// deepCopyAndInstrument mirrors FullCopyV3Chart but rewrites template Data with
+// instrumented bytes. It must produce a chart whose structure is otherwise
+// identical to FullCopyV3Chart's output so the engine treats it the same way.
+func (t *Tracker) deepCopyAndInstrument(in *v3chart.Chart, route string) *v3chart.Chart {
+	out := new(v3chart.Chart)
+
+	// Raw files (Chart.yaml, values.yaml, ...) — copy as-is.
+	for _, rf := range in.Raw {
+		c := *rf
+		out.Raw = append(out.Raw, &c)
+	}
+
+	if in.Metadata != nil {
+		md := *in.Metadata
+		out.Metadata = &md
+	}
+
+	out.Values = in.Values
+	out.Schema = in.Schema
+
+	// Static files (anything not under templates/).
+	for _, f := range in.Files {
+		c := *f
+		out.Files = append(out.Files, &c)
+	}
+
+	// Templates — instrument each.
+	for _, tmpl := range in.Templates {
+		copied := &v3chart.File{Name: tmpl.Name}
+
+		// Only instrument YAML / TPL templates. Other files (txt, json, etc.)
+		// might appear in templates/ and we don't tamper with them.
+		if shouldInstrument(tmpl.Name) {
+			key := metaKey(route, tmpl.Name)
+			instrumented, meta := t.Instrument(key, tmpl.Data)
+			copied.Data = instrumented
+			t.registerTemplateMeta(key, meta)
+		} else {
+			copied.Data = append([]byte(nil), tmpl.Data...)
+		}
+		out.Templates = append(out.Templates, copied)
+	}
+
+	// Recurse into dependencies, mirroring FullCopyV3Chart's route convention.
+	depRoute := func(dep *v3chart.Chart) string {
+		return filepath.ToSlash(filepath.Join(route, "charts", dep.Name()))
+	}
+	deps := make([]*v3chart.Chart, 0, len(in.Dependencies()))
+	for _, d := range in.Dependencies() {
+		deps = append(deps, t.deepCopyAndInstrument(d, depRoute(d)))
+	}
+	out.SetDependencies(deps...)
+
+	return out
+}
+
+// metaKey is the unique per-template key used to look up coverage metadata.
+// Always slash-separated so it sorts/searches predictably across platforms.
+func metaKey(chartRoute, templateName string) string {
+	return filepath.ToSlash(filepath.Join(chartRoute, templateName))
+}
+
+func shouldInstrument(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".yml" || ext == ".tpl"
+}
+
+func (t *Tracker) registerProbe(p Probe) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.probes = append(t.probes, p)
+	t.hits = append(t.hits, 0)
+	return len(t.probes) - 1
+}
+
+func (t *Tracker) registerTemplateMeta(key string, meta TemplateMeta) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.templateMetas[key] = meta
+	t.templateOrder = append(t.templateOrder, key)
+}
+
+// InstrumentedChart returns the deep-copied, instrumented chart suitable for
+// rendering through helm.sh/helm/v3/pkg/engine.
+func (t *Tracker) InstrumentedChart() *v3chart.Chart {
+	return t.instrumentedChart
+}
+
+// HasProbes reports whether any probe was registered. When false, rendering
+// the instrumented chart will still work, but there will be nothing meaningful
+// to report.
+func (t *Tracker) HasProbes() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.probes) > 0
+}
+
+var probeTokenRe = regexp.MustCompile(regexp.QuoteMeta(tokenPrefix) + `(\d+)` + regexp.QuoteMeta(tokenSuffix))
+
+// Absorb scans the output map produced by v3engine.Render for probe tokens and
+// increments hit counts. It is safe to call from concurrent goroutines.
+func (t *Tracker) Absorb(rendered map[string]string) {
+	if len(rendered) == 0 {
+		return
+	}
+	local := make(map[int]int)
+	for _, content := range rendered {
+		matches := probeTokenRe.FindAllStringSubmatch(content, -1)
+		for _, m := range matches {
+			idx, err := strconv.Atoi(m[1])
+			if err != nil {
+				continue
+			}
+			local[idx]++
+		}
+	}
+	if len(local) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for idx, n := range local {
+		if idx >= 0 && idx < len(t.hits) {
+			t.hits[idx] += int64(n)
+		} else {
+			log.WithField(logField, "absorb").Debugf("probe index %d out of range", idx)
+		}
+	}
+}
+
+// Snapshot freezes the current tracker state into a stable Coverage struct.
+func (t *Tracker) Snapshot() Coverage {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	cov := Coverage{ChartName: t.chartName}
+
+	// Group probe indexes per template for fast lookup.
+	for _, key := range t.templateOrder {
+		meta := t.templateMetas[key]
+		fc := FileCoverage{Name: key, ParseError: meta.ParseError}
+		uncoveredLines := map[int]struct{}{}
+		lineAcc := map[int]*LineCoverage{}
+		for _, pi := range meta.ProbeIdxs {
+			p := t.probes[pi]
+			hits := int(t.hits[pi])
+			hit := hits > 0
+			switch p.Kind {
+			case ProbeAction:
+				fc.Actions.Total++
+				fc.Actions.Hits += int64(hits)
+				if hit {
+					fc.Actions.Covered++
+				}
+			case ProbeBranch:
+				fc.Branches.Total++
+				fc.Branches.Hits += int64(hits)
+				if hit {
+					fc.Branches.Covered++
+				}
+			case ProbeLoop:
+				fc.Loops.Total++
+				fc.Loops.Hits += int64(hits)
+				if hit {
+					fc.Loops.Covered++
+				}
+			}
+			if !hit {
+				uncoveredLines[p.Line] = struct{}{}
+			}
+
+			line := lineAcc[p.Line]
+			if line == nil {
+				line = &LineCoverage{Line: p.Line}
+				lineAcc[p.Line] = line
+			}
+			if hits > line.Hits {
+				line.Hits = hits
+			}
+			if p.Kind == ProbeBranch || p.Kind == ProbeLoop {
+				line.Branches = append(line.Branches, BranchCoverage{Label: p.Label, Hits: hits})
+			}
+		}
+		fc.MissedLines = sortedKeys(uncoveredLines)
+		fc.Lines = make([]LineCoverage, 0, len(lineAcc))
+		for _, lc := range lineAcc {
+			fc.Lines = append(fc.Lines, *lc)
+		}
+		sort.Slice(fc.Lines, func(i, j int) bool { return fc.Lines[i].Line < fc.Lines[j].Line })
+
+		cov.Totals.Actions.Total += fc.Actions.Total
+		cov.Totals.Actions.Covered += fc.Actions.Covered
+		cov.Totals.Actions.Hits += fc.Actions.Hits
+		cov.Totals.Branches.Total += fc.Branches.Total
+		cov.Totals.Branches.Covered += fc.Branches.Covered
+		cov.Totals.Branches.Hits += fc.Branches.Hits
+		cov.Totals.Loops.Total += fc.Loops.Total
+		cov.Totals.Loops.Covered += fc.Loops.Covered
+		cov.Totals.Loops.Hits += fc.Loops.Hits
+
+		cov.Files = append(cov.Files, fc)
+	}
+
+	// Stable alphabetic order makes the report deterministic across runs.
+	sort.Slice(cov.Files, func(i, j int) bool {
+		return cov.Files[i].Name < cov.Files[j].Name
+	})
+	return cov
+}
+
+func sortedKeys(m map[int]struct{}) []int {
+	keys := make([]int, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
+}

--- a/pkg/unittest/coverage/tracker.go
+++ b/pkg/unittest/coverage/tracker.go
@@ -44,6 +44,23 @@ type Tracker struct {
 	// (and all subcharts' Templates) have been swapped for instrumented bytes.
 	// We retain it so test jobs can reuse it without re-instrumenting per run.
 	instrumentedChart *v3chart.Chart
+
+	// includeSubcharts controls whether dependency-chart templates are
+	// instrumented. When false, subchart templates are copied into the
+	// instrumented chart verbatim so the parent's `include`/`template` calls
+	// still work, but no probes are registered for them and they stay out of
+	// the coverage report. Mirrors helm-unittest's --with-subchart flag.
+	includeSubcharts bool
+}
+
+// TrackerOption configures a Tracker at construction time.
+type TrackerOption func(*Tracker)
+
+// WithSubcharts controls whether dependency-chart templates are instrumented
+// and included in coverage reports. Default is true (matches helm-unittest's
+// --with-subchart default).
+func WithSubcharts(include bool) TrackerOption {
+	return func(t *Tracker) { t.includeSubcharts = include }
 }
 
 // NewTracker constructs a tracker by instrumenting every template in the chart
@@ -53,20 +70,29 @@ type Tracker struct {
 //
 // The returned tracker owns its own deep copy of the chart; the input is not
 // modified.
-func NewTracker(chart *v3chart.Chart) *Tracker {
+func NewTracker(chart *v3chart.Chart, opts ...TrackerOption) *Tracker {
 	t := &Tracker{
-		chartName:     chart.Name(),
-		templateMetas: map[string]TemplateMeta{},
-		renderedFiles: map[string]bool{},
+		chartName:        chart.Name(),
+		templateMetas:    map[string]TemplateMeta{},
+		renderedFiles:    map[string]bool{},
+		includeSubcharts: true,
 	}
-	t.instrumentedChart = t.deepCopyAndInstrument(chart, chart.Name())
+	for _, opt := range opts {
+		opt(t)
+	}
+	t.instrumentedChart = t.deepCopyAndInstrument(chart, chart.Name(), true)
 	return t
 }
 
 // deepCopyAndInstrument mirrors FullCopyV3Chart but rewrites template Data with
 // instrumented bytes. It must produce a chart whose structure is otherwise
 // identical to FullCopyV3Chart's output so the engine treats it the same way.
-func (t *Tracker) deepCopyAndInstrument(in *v3chart.Chart, route string) *v3chart.Chart {
+//
+// When instrument is false the templates are copied verbatim — useful for
+// subcharts when the user has set --with-subchart=false: Helm still renders
+// them (so `include`/`template` from the parent still resolves), but no probes
+// are registered for them so they don't appear in coverage reports.
+func (t *Tracker) deepCopyAndInstrument(in *v3chart.Chart, route string, instrument bool) *v3chart.Chart {
 	out := new(v3chart.Chart)
 
 	// Raw files (Chart.yaml, values.yaml, ...) — copy as-is.
@@ -89,13 +115,13 @@ func (t *Tracker) deepCopyAndInstrument(in *v3chart.Chart, route string) *v3char
 		out.Files = append(out.Files, &c)
 	}
 
-	// Templates — instrument each.
+	// Templates — instrument each (or copy verbatim when instrument is false).
 	for _, tmpl := range in.Templates {
 		copied := &v3chart.File{Name: tmpl.Name}
 
 		// Only instrument YAML / TPL templates. Other files (txt, json, etc.)
 		// might appear in templates/ and we don't tamper with them.
-		if shouldInstrument(tmpl.Name) {
+		if instrument && shouldInstrument(tmpl.Name) {
 			key := metaKey(route, tmpl.Name)
 			instrumented, meta := t.Instrument(key, tmpl.Data)
 			copied.Data = instrumented
@@ -107,12 +133,14 @@ func (t *Tracker) deepCopyAndInstrument(in *v3chart.Chart, route string) *v3char
 	}
 
 	// Recurse into dependencies, mirroring FullCopyV3Chart's route convention.
+	// Subcharts are instrumented only when the tracker was configured to
+	// include them (i.e. helm-unittest --with-subchart is true).
 	depRoute := func(dep *v3chart.Chart) string {
 		return filepath.ToSlash(filepath.Join(route, "charts", dep.Name()))
 	}
 	deps := make([]*v3chart.Chart, 0, len(in.Dependencies()))
 	for _, d := range in.Dependencies() {
-		deps = append(deps, t.deepCopyAndInstrument(d, depRoute(d)))
+		deps = append(deps, t.deepCopyAndInstrument(d, depRoute(d), t.includeSubcharts))
 	}
 	out.SetDependencies(deps...)
 

--- a/pkg/unittest/coverage/tracker.go
+++ b/pkg/unittest/coverage/tracker.go
@@ -35,6 +35,10 @@ type Tracker struct {
 	// templateOrder preserves the insertion order so reports list files in a
 	// stable, source-like order.
 	templateOrder []string
+	// renderedFiles records which template-file keys produced non-empty output
+	// (after probe tokens are stripped) in at least one Absorb call. Used to
+	// flag templates that were never exercised by any test.
+	renderedFiles map[string]bool
 
 	// instrumentedChart is a deep clone of the input chart whose Templates
 	// (and all subcharts' Templates) have been swapped for instrumented bytes.
@@ -53,6 +57,7 @@ func NewTracker(chart *v3chart.Chart) *Tracker {
 	t := &Tracker{
 		chartName:     chart.Name(),
 		templateMetas: map[string]TemplateMeta{},
+		renderedFiles: map[string]bool{},
 	}
 	t.instrumentedChart = t.deepCopyAndInstrument(chart, chart.Name())
 	return t
@@ -157,14 +162,17 @@ func (t *Tracker) HasProbes() bool {
 
 var probeTokenRe = regexp.MustCompile(regexp.QuoteMeta(tokenPrefix) + `(\d+)` + regexp.QuoteMeta(tokenSuffix))
 
-// Absorb scans the output map produced by v3engine.Render for probe tokens and
-// increments hit counts. It is safe to call from concurrent goroutines.
+// Absorb scans the output map produced by v3engine.Render for probe tokens,
+// increments hit counts, and records which files produced non-empty output
+// (with probe tokens stripped) so the Rendered flag can be set. It is safe to
+// call from concurrent goroutines.
 func (t *Tracker) Absorb(rendered map[string]string) {
 	if len(rendered) == 0 {
 		return
 	}
 	local := make(map[int]int)
-	for _, content := range rendered {
+	rendNonEmpty := make(map[string]bool)
+	for key, content := range rendered {
 		matches := probeTokenRe.FindAllStringSubmatch(content, -1)
 		for _, m := range matches {
 			idx, err := strconv.Atoi(m[1])
@@ -173,9 +181,13 @@ func (t *Tracker) Absorb(rendered map[string]string) {
 			}
 			local[idx]++
 		}
-	}
-	if len(local) == 0 {
-		return
+		// Detect "did this file produce anything real?" by stripping our own
+		// probe tokens and checking whether the remaining text has any
+		// non-whitespace characters.
+		cleaned := probeTokenRe.ReplaceAllString(content, "")
+		if strings.TrimSpace(cleaned) != "" {
+			rendNonEmpty[key] = true
+		}
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -185,6 +197,9 @@ func (t *Tracker) Absorb(rendered map[string]string) {
 		} else {
 			log.WithField(logField, "absorb").Debugf("probe index %d out of range", idx)
 		}
+	}
+	for key := range rendNonEmpty {
+		t.renderedFiles[key] = true
 	}
 }
 
@@ -251,6 +266,13 @@ func (t *Tracker) Snapshot() Coverage {
 			fc.Lines = append(fc.Lines, *lc)
 		}
 		sort.Slice(fc.Lines, func(i, j int) bool { return fc.Lines[i].Line < fc.Lines[j].Line })
+
+		// A template is "rendered" if it produced non-empty output of its own
+		// in any test, OR if any of its probes were exercised (the latter
+		// catches partial _.tpl templates whose define blocks were called via
+		// include from elsewhere — those don't render content directly).
+		fc.Rendered = t.renderedFiles[key] ||
+			fc.Actions.Covered+fc.Branches.Covered+fc.Loops.Covered > 0
 
 		cov.Totals.Actions.Total += fc.Actions.Total
 		cov.Totals.Actions.Covered += fc.Actions.Covered

--- a/pkg/unittest/coverage/tracker.go
+++ b/pkg/unittest/coverage/tracker.go
@@ -198,7 +198,7 @@ func (t *Tracker) Snapshot() Coverage {
 	// Group probe indexes per template for fast lookup.
 	for _, key := range t.templateOrder {
 		meta := t.templateMetas[key]
-		fc := FileCoverage{Name: key, ParseError: meta.ParseError}
+		fc := FileCoverage{Name: key, ParseError: meta.ParseError, Source: meta.Source}
 		uncoveredLines := map[int]struct{}{}
 		lineAcc := map[int]*LineCoverage{}
 		for _, pi := range meta.ProbeIdxs {
@@ -236,6 +236,10 @@ func (t *Tracker) Snapshot() Coverage {
 			}
 			if hits > line.Hits {
 				line.Hits = hits
+			}
+			line.ProbesTotal++
+			if hit {
+				line.ProbesCovered++
 			}
 			if p.Kind == ProbeBranch || p.Kind == ProbeLoop {
 				line.Branches = append(line.Branches, BranchCoverage{Label: p.Label, Hits: hits})

--- a/pkg/unittest/coverage/tracker_test.go
+++ b/pkg/unittest/coverage/tracker_test.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -159,6 +160,88 @@ metadata:
 		"static.yaml has no probes but renders non-empty content")
 	assert.False(t, byName["covtest/templates/gated.yaml"].Rendered,
 		"gated.yaml renders empty when .Values.on is false")
+}
+
+func TestTracker_WithSubcharts_FalseSkipsSubchartTemplates(t *testing.T) {
+	// Parent chart that includes a helper defined in a subchart.
+	parent := buildTestChart("parentchart", map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    team: {{ include "sub.label" . }}
+`,
+	})
+	sub := buildTestChart("subchart", map[string]string{
+		"templates/_helpers.tpl": `{{- define "sub.label" -}}
+{{- .Values.team | default "default" -}}
+{{- end -}}`,
+		"templates/svc.yaml": `apiVersion: v1
+kind: Service
+metadata:
+  name: sub-svc
+`,
+	})
+	parent.SetDependencies(sub)
+
+	tracker := NewTracker(parent, WithSubcharts(false))
+	instrumented := tracker.InstrumentedChart()
+
+	// The instrumented chart must still carry the subchart so the parent's
+	// `include` call resolves at render time.
+	require.Len(t, instrumented.Dependencies(), 1, "subchart still attached")
+
+	vals, err := v3util.ToRenderValues(instrumented, map[string]any{}, v3util.ReleaseOptions{
+		Name: "rel", Namespace: "ns", IsInstall: true,
+	}, nil)
+	require.NoError(t, err)
+	out, err := v3engine.Render(instrumented, vals)
+	require.NoError(t, err)
+	tracker.Absorb(out)
+
+	cov := tracker.Snapshot()
+	for _, f := range cov.Files {
+		assert.NotContains(t, f.Name, "/charts/subchart/",
+			"subchart template %q must not appear when WithSubcharts(false)", f.Name)
+	}
+	// Parent chart's own template is still there.
+	var sawParent bool
+	for _, f := range cov.Files {
+		if f.Name == "parentchart/templates/cm.yaml" {
+			sawParent = true
+		}
+	}
+	assert.True(t, sawParent, "parent template should still be reported")
+}
+
+func TestTracker_WithSubcharts_DefaultIncludes(t *testing.T) {
+	// Same chart but with subcharts enabled (default) — subchart templates
+	// must show up in the report.
+	parent := buildTestChart("parentchart", map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    team: {{ include "sub.label" . }}
+`,
+	})
+	sub := buildTestChart("subchart", map[string]string{
+		"templates/_helpers.tpl": `{{- define "sub.label" -}}
+{{- .Values.team | default "default" -}}
+{{- end -}}`,
+	})
+	parent.SetDependencies(sub)
+
+	tracker := NewTracker(parent) // default: WithSubcharts(true)
+	cov := tracker.Snapshot()
+
+	var sawSub bool
+	for _, f := range cov.Files {
+		if strings.Contains(f.Name, "/charts/subchart/") {
+			sawSub = true
+		}
+	}
+	assert.True(t, sawSub, "subchart template should appear by default")
 }
 
 func TestTracker_PartialTemplateInstrumented(t *testing.T) {

--- a/pkg/unittest/coverage/tracker_test.go
+++ b/pkg/unittest/coverage/tracker_test.go
@@ -110,6 +110,57 @@ data:
 	assert.NotEmpty(t, cov.Files[0].MissedLines)
 }
 
+func TestTracker_RenderedFlag(t *testing.T) {
+	// Chart with three templates:
+	//   live.yaml  — renders unconditionally (always non-empty)
+	//   gated.yaml — content wrapped in `{{ if .Values.on }}…{{ end }}`
+	//   static.yaml — plain YAML with no Go-template actions at all
+	chart := buildTestChart("covtest", map[string]string{
+		"templates/live.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: live
+`,
+		"templates/gated.yaml": `{{- if .Values.on }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gated
+{{- end }}
+`,
+		"templates/static.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: static
+`,
+	})
+
+	tracker := NewTracker(chart)
+	instrumented := tracker.InstrumentedChart()
+
+	// Render with .Values.on absent so gated.yaml produces no content.
+	vals, err := v3util.ToRenderValues(instrumented, map[string]any{}, v3util.ReleaseOptions{
+		Name: "rel", Namespace: "ns", IsInstall: true,
+	}, nil)
+	require.NoError(t, err)
+	out, err := v3engine.Render(instrumented, vals)
+	require.NoError(t, err)
+	tracker.Absorb(out)
+
+	cov := tracker.Snapshot()
+	byName := map[string]FileCoverage{}
+	for _, f := range cov.Files {
+		byName[f.Name] = f
+	}
+
+	assert.True(t, byName["covtest/templates/live.yaml"].Rendered,
+		"live.yaml renders content unconditionally")
+	assert.True(t, byName["covtest/templates/static.yaml"].Rendered,
+		"static.yaml has no probes but renders non-empty content")
+	assert.False(t, byName["covtest/templates/gated.yaml"].Rendered,
+		"gated.yaml renders empty when .Values.on is false")
+}
+
 func TestTracker_PartialTemplateInstrumented(t *testing.T) {
 	chart := buildTestChart("covtest", map[string]string{
 		"templates/_helpers.tpl": `{{- define "covtest.label" -}}

--- a/pkg/unittest/coverage/tracker_test.go
+++ b/pkg/unittest/coverage/tracker_test.go
@@ -1,0 +1,152 @@
+package coverage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v3chart "helm.sh/helm/v3/pkg/chart"
+	v3util "helm.sh/helm/v3/pkg/chartutil"
+	v3engine "helm.sh/helm/v3/pkg/engine"
+)
+
+// buildTestChart builds an in-memory chart with the supplied templates.
+// Each template entry maps a Name (e.g. "templates/foo.yaml") to its raw body.
+func buildTestChart(name string, templates map[string]string) *v3chart.Chart {
+	c := &v3chart.Chart{
+		Metadata: &v3chart.Metadata{
+			Name:       name,
+			Version:    "0.0.1",
+			APIVersion: v3chart.APIVersionV2,
+		},
+	}
+	for n, body := range templates {
+		c.Templates = append(c.Templates, &v3chart.File{Name: n, Data: []byte(body)})
+	}
+	return c
+}
+
+func TestTracker_BranchHitsDifferByValues(t *testing.T) {
+	chart := buildTestChart("covtest", map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+data:
+{{- if .Values.enabled }}
+  flag: "on"
+{{- else }}
+  flag: "off"
+{{- end }}
+{{- range $k, $v := .Values.items }}
+  {{ $k }}: {{ $v | quote }}
+{{- end }}
+`,
+	})
+
+	tracker := NewTracker(chart)
+	require.True(t, tracker.HasProbes())
+
+	render := func(values map[string]any) {
+		instrumented := tracker.InstrumentedChart()
+		vals, err := v3util.ToRenderValues(instrumented, values, v3util.ReleaseOptions{
+			Name:      "rel",
+			Namespace: "ns",
+			IsInstall: true,
+		}, nil)
+		require.NoError(t, err)
+		out, err := v3engine.Render(instrumented, vals)
+		require.NoError(t, err)
+		tracker.Absorb(out)
+	}
+
+	render(map[string]any{"enabled": true, "items": map[string]any{"a": "1"}})
+	render(map[string]any{"enabled": false})
+
+	cov := tracker.Snapshot()
+	require.Len(t, cov.Files, 1)
+	f := cov.Files[0]
+
+	// Both if and else branches were hit across the two renders.
+	assert.Equal(t, 2, f.Branches.Covered, "if + else should both have been hit")
+	assert.Equal(t, 2, f.Branches.Total)
+	// Range body was hit at least once (in the first render).
+	assert.Equal(t, 1, f.Loops.Covered)
+	assert.Equal(t, 1, f.Loops.Total)
+	// Totals should mirror file aggregates for a single-file chart.
+	assert.Equal(t, f.Actions.Total, cov.Totals.Actions.Total)
+	assert.Equal(t, f.Branches.Covered, cov.Totals.Branches.Covered)
+}
+
+func TestTracker_UncoveredLinesReported(t *testing.T) {
+	chart := buildTestChart("covtest", map[string]string{
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+data:
+{{- if .Values.enabled }}
+  yes: "1"
+{{- else }}
+  no: "1"
+{{- end }}
+`,
+	})
+
+	tracker := NewTracker(chart)
+	instrumented := tracker.InstrumentedChart()
+
+	vals, err := v3util.ToRenderValues(instrumented, map[string]any{"enabled": true}, v3util.ReleaseOptions{
+		Name:      "rel",
+		Namespace: "ns",
+		IsInstall: true,
+	}, nil)
+	require.NoError(t, err)
+	out, err := v3engine.Render(instrumented, vals)
+	require.NoError(t, err)
+	tracker.Absorb(out)
+
+	cov := tracker.Snapshot()
+	require.Len(t, cov.Files, 1)
+	// The else branch was not exercised; its source line must be reported.
+	assert.NotEmpty(t, cov.Files[0].MissedLines)
+}
+
+func TestTracker_PartialTemplateInstrumented(t *testing.T) {
+	chart := buildTestChart("covtest", map[string]string{
+		"templates/_helpers.tpl": `{{- define "covtest.label" -}}
+{{- if .Values.team }}{{ .Values.team }}{{- else }}default{{- end }}
+{{- end -}}`,
+		"templates/cm.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  labels:
+    team: {{ include "covtest.label" . }}
+`,
+	})
+
+	tracker := NewTracker(chart)
+	instrumented := tracker.InstrumentedChart()
+	vals, err := v3util.ToRenderValues(instrumented, map[string]any{}, v3util.ReleaseOptions{
+		Name:      "rel",
+		Namespace: "ns",
+		IsInstall: true,
+	}, nil)
+	require.NoError(t, err)
+	out, err := v3engine.Render(instrumented, vals)
+	require.NoError(t, err)
+	tracker.Absorb(out)
+
+	cov := tracker.Snapshot()
+	// Both files should appear in the report.
+	require.Len(t, cov.Files, 2)
+	// Only the else branch in _helpers.tpl was exercised (no .Values.team).
+	var helperFile *FileCoverage
+	for i := range cov.Files {
+		if cov.Files[i].Name == "covtest/templates/_helpers.tpl" {
+			helperFile = &cov.Files[i]
+		}
+	}
+	require.NotNil(t, helperFile, "helpers.tpl should be tracked")
+	assert.Equal(t, 1, helperFile.Branches.Covered, "only the else branch ran")
+	assert.Equal(t, 2, helperFile.Branches.Total)
+}

--- a/pkg/unittest/coverage/types.go
+++ b/pkg/unittest/coverage/types.go
@@ -38,17 +38,25 @@ type FileCoverage struct {
 	Loops       CountStat
 	MissedLines []int          // 1-based source lines that were never executed
 	Lines       []LineCoverage // per-line breakdown, sorted by Line
+	// Source is the original template bytes. It is needed to render the HTML
+	// report's source-annotated view and is therefore kept on the snapshot;
+	// JSON output skips it to keep reports small.
+	Source []byte `json:"-"`
 }
 
 // LineCoverage is the aggregated coverage for a single source line within a
 // template file. Hits is the maximum hit count across every probe that sits on
 // the line — it represents "how many times this line executed". Branches lists
 // each branch/loop probe on the line individually, which is what LCOV and
-// Cobertura need in order to emit per-condition data.
+// Cobertura need in order to emit per-condition data. ProbesCovered /
+// ProbesTotal are what the HTML report uses to colour the line (covered /
+// missed / partial) without needing to re-walk individual probe hits.
 type LineCoverage struct {
-	Line     int
-	Hits     int
-	Branches []BranchCoverage
+	Line          int
+	Hits          int
+	Branches      []BranchCoverage
+	ProbesCovered int
+	ProbesTotal   int
 }
 
 // BranchCoverage is a single branch-style probe (if / else / with / range body

--- a/pkg/unittest/coverage/types.go
+++ b/pkg/unittest/coverage/types.go
@@ -1,0 +1,88 @@
+package coverage
+
+// ProbeKind classifies what kind of template construct a probe is tracking.
+type ProbeKind string
+
+const (
+	// ProbeAction is a plain {{ ... }} action (variable read, assignment, function call, template invocation).
+	ProbeAction ProbeKind = "action"
+	// ProbeBranch is one branch of an if/else/with construct.
+	ProbeBranch ProbeKind = "branch"
+	// ProbeLoop is the body (or else-body) of a range construct.
+	ProbeLoop ProbeKind = "loop"
+)
+
+// Probe describes a single instrumentation point in a template.
+type Probe struct {
+	Kind         ProbeKind
+	TemplateName string // path of the template file, e.g. "templates/deployment.yaml"
+	Line         int    // 1-based line in the source
+	Col          int    // 1-based column in the source
+	Label        string // short human label, e.g. "if", "else", "range-body", "range-else"
+}
+
+// TemplateMeta describes the instrumentation result for one template file.
+type TemplateMeta struct {
+	Name       string  // template file path within the chart
+	ProbeIdxs  []int   // indexes into Tracker.Probes for probes belonging to this file (in source order)
+	ParseError error   // non-nil if the template could not be parsed
+	Source     []byte  // original file content (kept for line lookup in reports)
+}
+
+// FileCoverage is the aggregated coverage for a single template file.
+type FileCoverage struct {
+	Name        string
+	ParseError  error
+	Actions     CountStat
+	Branches    CountStat
+	Loops       CountStat
+	MissedLines []int          // 1-based source lines that were never executed
+	Lines       []LineCoverage // per-line breakdown, sorted by Line
+}
+
+// LineCoverage is the aggregated coverage for a single source line within a
+// template file. Hits is the maximum hit count across every probe that sits on
+// the line — it represents "how many times this line executed". Branches lists
+// each branch/loop probe on the line individually, which is what LCOV and
+// Cobertura need in order to emit per-condition data.
+type LineCoverage struct {
+	Line     int
+	Hits     int
+	Branches []BranchCoverage
+}
+
+// BranchCoverage is a single branch-style probe (if / else / with / range body
+// / range else) on a line.
+type BranchCoverage struct {
+	Label string
+	Hits  int
+}
+
+// CountStat is covered/total for a coverage dimension. Hits is the sum of
+// actual execution counts across all probes — useful for loops where the
+// difference between "ran 1 time" and "ran 1000 times" matters. For action /
+// branch probes Hits is informational and typically >= Covered.
+type CountStat struct {
+	Covered int
+	Total   int
+	Hits    int64
+}
+
+// Pct returns the coverage percentage [0,100], or -1 when Total == 0 (N/A).
+func (c CountStat) Pct() float64 {
+	if c.Total == 0 {
+		return -1
+	}
+	return 100.0 * float64(c.Covered) / float64(c.Total)
+}
+
+// Coverage is the top-level coverage snapshot.
+type Coverage struct {
+	ChartName string
+	Files     []FileCoverage
+	Totals    struct {
+		Actions  CountStat
+		Branches CountStat
+		Loops    CountStat
+	}
+}

--- a/pkg/unittest/coverage/types.go
+++ b/pkg/unittest/coverage/types.go
@@ -42,6 +42,13 @@ type FileCoverage struct {
 	// report's source-annotated view and is therefore kept on the snapshot;
 	// JSON output skips it to keep reports small.
 	Source []byte `json:"-"`
+	// Rendered reports whether at least one test caused this template to
+	// contribute output. It is true if (a) the template rendered non-empty
+	// content of its own in any test, or (b) it is a partial template whose
+	// define-block probes were exercised via `template` / `include` calls
+	// from other templates. False means the file existed in the chart but no
+	// test exercised it — useful for spotting dead templates.
+	Rendered bool
 }
 
 // LineCoverage is the aggregated coverage for a single source line within a

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -2,6 +2,7 @@ package unittest
 
 import (
 	"github.com/helm-unittest/helm-unittest/internal/common"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/coverage"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/validators"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/valueutils"
@@ -15,6 +16,7 @@ type TestConfig struct {
 	failFast            bool
 	isSkipEmptyTemplate bool
 	postRenderer        PostRendererConfig
+	coverageTracker     *coverage.Tracker
 }
 
 func NewTestConfig(chart *v3chart.Chart, cache *snapshot.Cache, options ...func(*TestConfig)) *TestConfig {
@@ -65,6 +67,15 @@ func WithPostRendererConfig(config PostRendererConfig) LoadTestOptionsFunc {
 func WithSkipEmptyTemplate(config bool) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
 		c.isSkipEmptyTemplate = config
+	}
+}
+
+// WithCoverageTracker attaches a coverage tracker so the test job runs an
+// extra instrumented render after its primary render and contributes hit
+// counts back to the tracker. When tr is nil, coverage is disabled.
+func WithCoverageTracker(tr *coverage.Tracker) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		c.coverageTracker = tr
 	}
 }
 

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -16,6 +16,7 @@ import (
 	"helm.sh/helm/v3/pkg/postrender"
 
 	"github.com/helm-unittest/helm-unittest/internal/common"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/coverage"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/results"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/valueutils"
@@ -296,8 +297,71 @@ func (t *TestJob) RunV3(
 	}
 
 	result.Passed, result.AssertsResult = t.runAssertions(assertionsConfig)
+
+	// Coverage runs as a side activity: render the same job against the
+	// tracker's instrumented chart, then absorb hit tokens from the output.
+	// Failures here are logged but never fail the user's test.
+	if tracker := t.configOrDefault().coverageTracker; tracker != nil {
+		if covOutput, covErr := t.renderForCoverage([]byte(userValues), tracker); covErr != nil {
+			log.WithField(LOG_TEST_JOB, "coverage-render").Debugf("coverage render failed: %v", covErr)
+		} else {
+			tracker.Absorb(covOutput)
+		}
+	}
+
 	result.Duration = time.Since(startTestRun)
 	return result
+}
+
+// renderForCoverage runs a duplicate render through the tracker's instrumented
+// chart so probe tokens are emitted into the output. The returned map is the
+// raw rendered-files map straight from v3engine.Render and is intended only
+// for token scanning — its contents are otherwise discarded.
+func (t *TestJob) renderForCoverage(userValues []byte, tracker *coverage.Tracker) (map[string]string, error) {
+	if tracker == nil {
+		return nil, nil
+	}
+	instrumented := tracker.InstrumentedChart()
+	if instrumented == nil {
+		return nil, nil
+	}
+
+	values, err := v3util.ReadValues(userValues)
+	if err != nil {
+		return nil, err
+	}
+	options := *t.releaseV3Option()
+	if t.Release.Name != "" {
+		if err = v3util.ValidateReleaseName(t.Release.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	// ProcessDependenciesWithMerge mutates the chart in place to apply
+	// dependency-condition logic. We call it on the instrumented copy so it
+	// sees the same value-driven enable/disable decisions as the primary
+	// render. Mutating the tracker's chart between renders is acceptable
+	// because the operation is deterministic for a given (chart, values) pair.
+	if err = v3util.ProcessDependenciesWithMerge(instrumented, values); err != nil {
+		return nil, err
+	}
+
+	vals, err := v3util.ToRenderValuesWithSchemaValidation(instrumented, values.AsMap(), options, t.capabilitiesV3(), false)
+	if err != nil {
+		return nil, err
+	}
+
+	t.ModifyChartMetadata(instrumented)
+	templatesToAssert := t.defaultTemplatesToAssert
+	if len(templatesToAssert) == 0 {
+		templatesToAssert = []string{multiWildcard}
+	}
+	filtered := CopyV3Chart(t.chartRoute, instrumented.Name(), templatesToAssert, t.defaultTemplatesToSkip, instrumented)
+
+	if len(t.KubernetesProvider.Objects) > 0 {
+		return v3engine.RenderWithClientProvider(filtered, vals, &t.KubernetesProvider)
+	}
+	return v3engine.Render(filtered, vals)
 }
 
 // liberally borrows from helm-template

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/coverage"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/formatter"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/printer"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/results"
@@ -76,6 +77,9 @@ type TestRunner struct {
 	WithSubChart     bool
 	Strict           bool
 	Failfast         bool
+	Coverage         bool
+	CoverageFile     string
+	CoverageFormat   string
 	TestFiles        []string
 	ChartTestsPath   string
 	ValuesFiles      []string
@@ -86,6 +90,7 @@ type TestRunner struct {
 	chartCounting    testUnitCounting
 	snapshotCounting totalSnapshotCounting
 	testResults      []*results.TestSuiteResult
+	coverageReports  []coverage.Coverage
 }
 
 // RunV3 test suites in chart in ChartPaths.
@@ -116,7 +121,20 @@ func (tr *TestRunner) RunV3(ChartPaths []string) bool {
 		}
 
 		tr.printChartHeader(chart.Name(), chartPath)
+
+		var tracker *coverage.Tracker
+		if tr.Coverage {
+			tracker = coverage.NewTracker(chart)
+			for _, suite := range testSuites {
+				suite.WithCoverageTracker(tracker)
+			}
+		}
+
 		chartPassed := tr.runV3SuitesOfChart(testSuites, chart)
+
+		if tracker != nil {
+			tr.coverageReports = append(tr.coverageReports, tracker.Snapshot())
+		}
 
 		tr.countChart(chartPassed, nil)
 		allPassed = allPassed && chartPassed
@@ -127,7 +145,44 @@ func (tr *TestRunner) RunV3(ChartPaths []string) bool {
 	}
 	tr.printSnapshotSummary()
 	tr.printSummary(time.Since(start))
+	tr.renderCoverage()
 	return allPassed
+}
+
+// renderCoverage prints the per-chart coverage tables collected during the run
+// and, when CoverageFile is set, writes the structured JSON report to disk.
+func (tr *TestRunner) renderCoverage() {
+	if len(tr.coverageReports) == 0 {
+		return
+	}
+	for _, cov := range tr.coverageReports {
+		coverage.RenderConsole(tr.Printer, cov)
+	}
+	if tr.CoverageFile == "" {
+		return
+	}
+	format := tr.CoverageFormat
+	if format == "" {
+		format = coverage.FormatJSON
+	}
+	// When a single chart was tested, write the chart's report directly.
+	// For multi-chart runs we still write the first chart's report at the
+	// configured path and a sibling file per additional chart, keyed by name.
+	if len(tr.coverageReports) == 1 {
+		if err := coverage.WriteReport(tr.CoverageFile, format, tr.coverageReports[0]); err != nil {
+			log.WithField(LOG_TEST_RUNNER, "coverage-report").Errorf("failed to write coverage report: %v", err)
+		}
+		return
+	}
+	for i, cov := range tr.coverageReports {
+		path := tr.CoverageFile
+		if i > 0 {
+			path = fmt.Sprintf("%s.%s", tr.CoverageFile, cov.ChartName)
+		}
+		if err := coverage.WriteReport(path, format, cov); err != nil {
+			log.WithField(LOG_TEST_RUNNER, "coverage-report").Errorf("failed to write coverage report for %s: %v", cov.ChartName, err)
+		}
+	}
 }
 
 // getTestSuites retrieves the list of test suites for the given chart.

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -150,7 +150,8 @@ func (tr *TestRunner) RunV3(ChartPaths []string) bool {
 }
 
 // renderCoverage prints the per-chart coverage tables collected during the run
-// and, when CoverageFile is set, writes the structured JSON report to disk.
+// and, when CoverageFile is set, writes a structured report in the format
+// chosen by CoverageFormat (json, cobertura or lcov; defaults to json).
 func (tr *TestRunner) renderCoverage() {
 	if len(tr.coverageReports) == 0 {
 		return

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -124,7 +124,12 @@ func (tr *TestRunner) RunV3(ChartPaths []string) bool {
 
 		var tracker *coverage.Tracker
 		if tr.Coverage {
-			tracker = coverage.NewTracker(chart)
+			// Mirror --with-subchart in coverage: when subchart tests are
+			// excluded from the run, their templates also stay out of the
+			// coverage report (but they're still copied into the
+			// instrumented chart so the parent's include/template calls
+			// continue to resolve).
+			tracker = coverage.NewTracker(chart, coverage.WithSubcharts(tr.WithSubChart))
 			for _, suite := range testSuites {
 				suite.WithCoverageTracker(tracker)
 			}

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -150,8 +150,10 @@ func (tr *TestRunner) RunV3(ChartPaths []string) bool {
 }
 
 // renderCoverage prints the per-chart coverage tables collected during the run
-// and, when CoverageFile is set, writes a structured report in the format
-// chosen by CoverageFormat (json, cobertura or lcov; defaults to json).
+// and, when CoverageFile is set, writes a structured report for each format
+// listed in CoverageFormat (comma-separated; defaults to json). When more than
+// one format is requested CoverageFile is treated as a path stem and the
+// per-format extension is appended for each output.
 func (tr *TestRunner) renderCoverage() {
 	if len(tr.coverageReports) == 0 {
 		return
@@ -162,26 +164,25 @@ func (tr *TestRunner) renderCoverage() {
 	if tr.CoverageFile == "" {
 		return
 	}
-	format := tr.CoverageFormat
-	if format == "" {
-		format = coverage.FormatJSON
-	}
-	// When a single chart was tested, write the chart's report directly.
-	// For multi-chart runs we still write the first chart's report at the
-	// configured path and a sibling file per additional chart, keyed by name.
-	if len(tr.coverageReports) == 1 {
-		if err := coverage.WriteReport(tr.CoverageFile, format, tr.coverageReports[0]); err != nil {
-			log.WithField(LOG_TEST_RUNNER, "coverage-report").Errorf("failed to write coverage report: %v", err)
-		}
+	formats, err := coverage.ParseFormats(tr.CoverageFormat)
+	if err != nil {
+		log.WithField(LOG_TEST_RUNNER, "coverage-format").Errorf("invalid --coverage-format: %v", err)
 		return
 	}
+	targets := coverage.ResolveOutputPaths(tr.CoverageFile, formats)
+
+	// For multi-chart runs the first chart uses the resolved path as-is and
+	// subsequent charts append a `.<chartName>` suffix to disambiguate. This
+	// matches the long-standing single-format behaviour.
 	for i, cov := range tr.coverageReports {
-		path := tr.CoverageFile
-		if i > 0 {
-			path = fmt.Sprintf("%s.%s", tr.CoverageFile, cov.ChartName)
-		}
-		if err := coverage.WriteReport(path, format, cov); err != nil {
-			log.WithField(LOG_TEST_RUNNER, "coverage-report").Errorf("failed to write coverage report for %s: %v", cov.ChartName, err)
+		for _, target := range targets {
+			path := target.Path
+			if i > 0 {
+				path = fmt.Sprintf("%s.%s", path, cov.ChartName)
+			}
+			if err := coverage.WriteReport(path, target.Format, cov); err != nil {
+				log.WithField(LOG_TEST_RUNNER, "coverage-report").Errorf("failed to write %s coverage report for %s: %v", target.Format, cov.ChartName, err)
+			}
 		}
 	}
 }

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/helm-unittest/helm-unittest/internal/build"
 	"github.com/helm-unittest/helm-unittest/internal/common"
+	"github.com/helm-unittest/helm-unittest/pkg/unittest/coverage"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/results"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
 	v3chart "helm.sh/helm/v3/pkg/chart"
@@ -246,6 +247,15 @@ type TestSuite struct {
 		// If the plugin version is less than the minimum version, skip the test suite
 		MinimumVersion string `yaml:"minimumVersion"`
 	} `yaml:"skip"`
+	// coverageTracker is attached by the runner when --coverage is enabled. It
+	// is not part of the YAML schema.
+	coverageTracker *coverage.Tracker `yaml:"-"`
+}
+
+// WithCoverageTracker attaches a tracker to this suite so jobs in it produce
+// coverage data alongside their primary render.
+func (s *TestSuite) WithCoverageTracker(tr *coverage.Tracker) {
+	s.coverageTracker = tr
 }
 
 // RunV3 runs all the test jobs defined in TestSuite.
@@ -266,6 +276,7 @@ func (s *TestSuite) RunV3(
 		snapshotCache,
 		failFast,
 		renderPath,
+		s.coverageTracker,
 	)
 
 	result.Passed = r.Pass
@@ -381,6 +392,7 @@ func (s *TestSuite) runV3TestJobs(
 	cache *snapshot.Cache,
 	failFast bool,
 	renderPath string,
+	tracker *coverage.Tracker,
 ) *SuiteResult {
 	result := SuiteResult{Pass: false, FailFast: false, Skip: false}
 	jobResults := make([]*results.TestJobResult, len(s.Tests))
@@ -406,6 +418,7 @@ func (s *TestSuite) runV3TestJobs(
 				WithFailFast(failFast),
 				WithPostRendererConfig(s.PostRendererConfig),
 				WithDocumentSelector(testJob.DocumentSelector),
+				WithCoverageTracker(tracker),
 			))
 			jobResult = testJob.RunV3(&job)
 			jobResults[idx] = jobResult


### PR DESCRIPTION
## Summary

Implements the long-requested **code coverage reporting** for chart templates — closes #156, open since 2021. The feature is fully opt-in: when users pass `--coverage`, helm-unittest parses each chart template via `text/template/parse`, injects unique probe tokens at every tracked AST node, deep-clones the chart with the instrumented bodies, and runs an *extra* render per test job through the clone. Probe tokens are scanned from the rendered output and aggregated per chart. **The assertion render path is unchanged**, so `--coverage` never affects test pass/fail.

Four file output formats ship in this PR: **JSON** (the project's own schema), **Cobertura XML**, **LCOV**, and **HTML** (a self-contained single-file report with embedded source). They can all be written from a **single run** — `--coverage-format` accepts a comma-separated list. Every format also surfaces a per-template **Rendered / Used** signal so dead templates are easy to spot.

## What's tracked

| Construct | Counted as |
|---|---|
| `{{ ... }}` actions, `{{ template "x" . }}` invocations | action |
| `if` / `else` / `else if`, `with` / `with-else` | branch |
| `range` body / `range-else` | loop (with per-iteration counts) |
| `default` / `ternary` at the end of an action pipe with a simple field/variable input | implicit branch (primary/fallback or true/false) |
| Whether the template file rendered non-empty output (or had any probe hit, for `_*.tpl` partials) | template-file `Rendered` flag |

Implicit branches are **only** emitted when re-evaluating the input expression is side-effect-free (no function calls before the helper). Pipelines like `{{ upper .X | default "y" }}` are silently skipped to avoid double-running `upper`.

Every probe carries its source line and column, so reports can identify uncovered lines per file.

## CLI

```
--coverage                  enable coverage reporting
--coverage-file PATH        write a report file (implies --coverage). For
                            multi-format output PATH is a stem and each
                            format appends its conventional extension.
--coverage-format FMT[,...] one or more of json | cobertura | lcov | html
                            (default: json)
```

Single-format example (path used verbatim):

```bash
helm unittest --coverage-format cobertura --coverage-file coverage.xml <chart>
```

Multi-format example (path is a stem; per-format extensions are appended):

```bash
helm unittest \
  --coverage-format cobertura,lcov,html,json \
  --coverage-file ./reports/cov \
  <chart>
# writes:
#   ./reports/cov.xml    (cobertura)
#   ./reports/cov.info   (lcov)
#   ./reports/cov.html   (html)
#   ./reports/cov.json   (json)
```

A trailing known extension on the stem is stripped first, so
`--coverage-file coverage.xml --coverage-format cobertura,html` writes
`coverage.xml` + `coverage.html`, not `coverage.xml.xml`.

## Output formats

| Format | Flag value | Consumed by / Purpose |
|---|---|---|
| Console (always on) | — | Per-file actions/branches/loops table with total iterations, a `Used` column (yes/no) summarising whether the template was exercised, and uncovered lines, printed after the test summary. |
| JSON (default file format) | `json` | Custom dashboards / scripts. Stable schema with totals, per-file stats, and a `rendered` boolean per file. |
| Cobertura XML | `cobertura` | Codecov, SonarQube, GitLab, Jenkins (Cobertura plugin), Azure DevOps. DTD-compliant `coverage-04` output with `<package>` per chart, `<class>` per template, `<line>` per source line, `condition-coverage` attributes for branches/loops, and a `helm-unittest-rendered` attribute on each `<class>`. |
| LCOV | `lcov` | Coveralls, Codecov, VS Code "Coverage Gutters", JetBrains import. One record per file with `SF` / `DA` / `BRDA` / `LF`/`LH` / `BRF`/`BRH`, plus a `# helm-unittest:rendered=…` comment line. |
| HTML | `html` | Self-contained single-file page — no external assets, no JS, dark-mode aware. Summary cards, sortable file list with green `used` / red `unused` pill per file, collapsible per-file `<details>` blocks with the original template source embedded and each line colour-coded **covered / missed / partial / neutral**, plus a hit-count column. Suitable as a CI artifact you can attach and open in a browser. |

## Implementation summary

New package `pkg/unittest/coverage/`:

| File | Purpose |
|---|---|
| `types.go` | `Probe`, `TemplateMeta`, `LineCoverage`, `FileCoverage`, `Coverage`, `CountStat` data types. `FileCoverage.Rendered` flag; `LineCoverage` carries `ProbesCovered`/`ProbesTotal` so HTML can colour lines accurately; `FileCoverage.Source` carries original template bytes for HTML rendering (excluded from JSON). |
| `instrumenter.go` | AST walker that emits instrumented template source with probe tokens. Uses `parse.SkipFuncCheck` so charts using any Helm/Sprig function parse without us tracking the full func map. |
| `implicit_branch.go` | Detects `default` / `ternary` calls at the end of an action pipe and emits side-probes for primary-vs-fallback / true-vs-false. Skips silently when re-evaluating the input would re-run a function call. |
| `tracker.go` | Deep-clones the chart with instrumented bodies, registers probes, absorbs rendered output (counting probe-token hits AND flagging files with non-empty real content), aggregates hits, builds the `Coverage` snapshot. |
| `reporter.go` | Console table writer (with `Used` column), JSON writer, plus the multi-format helpers: `ParseFormats`, `FormatExt`, `ResolveOutputPaths`, and the `WriteReport(path, format, cov)` dispatch. |
| `cobertura.go` | Cobertura 04 XML writer with `helm-unittest-rendered` attribute. |
| `lcov.go` | LCOV info writer with `# helm-unittest:rendered=…` comment lines. |
| `html.go` | Self-contained HTML report writer with inline CSS, used/unused pills, and `<details>`-based collapsibles. |

Wiring across the existing runner:
- `TestConfig.coverageTracker` + `WithCoverageTracker(...)` option.
- `TestSuite.coverageTracker` field, set by the runner before `TestSuite.RunV3`.
- `TestJob.RunV3` does an extra `v3engine.Render` against the tracker's instrumented chart after the primary render+assertions complete; failures are logged at debug and never fail the test.
- `TestRunner.{Coverage, CoverageFile, CoverageFormat}` + `renderCoverage()` driving console output and per-target file writes.
- New CLI flags wired in `cmd/helm-unittest/helm_unittest.go`.

Existing utilities reused:
- `FullCopyV3Chart` for deep-cloning the chart with subcharts.
- `CopyV3Chart` for applying the same template-include/skip rules during the coverage render.
- `v3engine.Render` / `v3engine.RenderWithClientProvider` for the actual render.
- `printer.Printer` for colored console output.

Templates that fail to parse are recorded with a `ParseError` and surfaced in the report (with their counters left empty) rather than silently dropped.

## Scope: `install-binary.sh` change is included

The PR also tweaks `install-binary.sh` to (1) detect installs from a non-upstream origin and build from source, and (2) fall back to a source build when the prebuilt-binary download fails — both behind opt-in env vars (`BUILD_FROM_SOURCE=1`, `HELM_UNITTEST_PROJECT_GH=<owner>/<repo>`). Upstream installs are unchanged.

Why it's in this PR rather than separate: it's what makes the **"install from this branch to test the PR"** flow below work without manual building. Happy to split it out into a separate PR if reviewers prefer — the coverage feature itself does not depend on it.

## Scoped out of this PR

- **Condition coverage inside compound pipelines** (`{{ if and .A .B }}` as two conditions): would require pipeline rewriting that can change runtime behavior for side-effectful funcs (`required`, `fail`, `tpl`, `include`). Skipped intentionally.

## Commits

| SHA | Subject |
|---|---|
| `3f98e27` | feat(coverage): add template coverage reporting with cobertura/lcov/json |
| `66842f4` | build(install-binary): build from source for fork branch installs |
| `e3a3911` | docs: correct renderCoverage comment to mention all formats |
| `797cb03` | feat(coverage): add HTML report format |
| `0323cfd` | fix(coverage/html): right-align numeric column headers in file list |
| `a20207c` | feat(coverage): surface per-file Rendered (Used) signal in all formats |
| `b8a4e71` | feat(coverage): write multiple report formats in a single run |

## Try it out (no rebase required)

Until this PR lands, reviewers can install the plugin directly from the fork branch and run it against any chart:

```bash
# uninstall any existing copy first (one-time)
helm plugin uninstall unittest || true

# install from this PR's branch — install-binary.sh detects the fork origin
# and builds the plugin from source (requires Go 1.24+ on PATH)
helm plugin install https://github.com/pkazi/helm-unittest.git --version coverage-feature-v1.0.3

# console coverage table (now includes a Used column)
helm unittest --coverage <chart-dir>

# one run, every format
helm unittest \
  --coverage-format cobertura,lcov,html,json \
  --coverage-file ./reports/cov \
  <chart-dir>
```

For air-gapped or no-Go CI runners, set `BUILD_FROM_SOURCE=0` and point `HELM_UNITTEST_PROJECT_GH` at a fork that publishes prebuilt releases.

## Heads up: rebase status

This branch was cut from tag `v1.0.3`; the PR currently shows merge conflicts because `main` has moved on (95 commits). The conflicts are all additive (upstream's new `SkipSchemaValidation` / `IncludeCrds` fields coexist cleanly with the new coverage fields). I've validated the resolution locally on a scratch branch — happy to rebase and force-push once reviewers have had a first-pass look, or now if you prefer.

## Test plan

- [x] `go test ./...` — all packages green
- [x] **30 unit / integration tests in `pkg/unittest/coverage/`** covering:
  - probe registration per kind, `define` block handling, parse errors
  - branch hits across multiple renders, uncovered-line reporting, partial template instrumentation
  - `default` / `ternary` detection (both call shapes), unsafe-pipeline skip, range iteration counts
  - per-file `Rendered` detection (live / gated-off / static-no-probes templates)
  - Cobertura XML structure + per-line / per-condition counts, class-name derivation, `helm-unittest-rendered` attribute
  - LCOV record format + per-line / per-branch counters, summary totals, `# helm-unittest:rendered` comment lines
  - HTML structure, per-line covered/missed/partial classes, anchor ID derivation, used/unused badges, format dispatch
  - Multi-format: `ParseFormats` (empty/whitespace/duplicates/unknown), `FormatExt`, `ResolveOutputPaths` (single verbatim, multi stem expansion, strip known extension, keep unknown extension), end-to-end write of all four formats from a single stem
- [x] Manual smoke against `pkg/unittest/testdata/chart-subchart-v1` (covers subcharts and `.tpl` partials)
- [x] Manual smoke against a 26-template real-world chart (219 tests / 702 ms) — produced valid Cobertura XML, LCOV info, JSON, and HTML reports in a single run from one `--coverage-file ./reports/cov` stem. **19/26 templates flagged as rendered, 7/26 as unused** across all four file formats. 244 covered / 110 missed / 9 partial / 932 neutral source lines.
- [x] Verified that without `--coverage`, console + file output is byte-identical to a build without these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
