### PR TITLE
Add metafile to verify publisher.

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,17 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: e3afd145-279b-41bd-b8be-b1a2155aaae5
+owners:
+  - name: Helm Unittest
+    email: helmunittest@gmail.com
+  - name: Quintus van Houdt
+    email: qvanhoudt@outlook.com


### PR DESCRIPTION
This pull request adds an `artifacthub-repo.yml` metadata file to the repository. The file defines repository ownership and configuration for Artifact Hub, specifying repository ID and listing owners with their contact information.

Repository metadata and ownership:

* Added `artifacthub-repo.yml` to configure Artifact Hub repository metadata, including repository ID and owner contact details.