### PR TITLE
build(deps): bump go version from 1.26.0 to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/helm-unittest/helm-unittest
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
## Summary

- Bump the Go minimum version directive in `go.mod` from `1.26.0` to `1.26.4`
- This resolves **23 known vulnerabilities** in the Go standard library (`stdlib`) identified by `osv-scanner`

## CVEs fixed

All 23 vulnerabilities are in `stdlib` and are fully fixed by Go 1.26.4:

| OSV ID | Fixed in |
|--------|----------|
| GO-2026-4599 through GO-2026-4603 | 1.26.1 |
| GO-2026-4864 through GO-2026-4870, GO-2026-4946, GO-2026-4947 | 1.26.2 |
| GO-2026-4918, GO-2026-4971, GO-2026-4976 through GO-2026-4982, GO-2026-4986 | 1.26.3 |
| GO-2026-5037, GO-2026-5038, GO-2026-5039 | 1.26.4 |

## Verification

`osv-scanner scan source -r .` reports **No issues found** after this change.

The build was verified with `golang:1.26.4` Docker image — no compilation errors.

## Test plan

- [x] `osv-scanner scan source -r .` → No issues found
- [x] `go build ./cmd/helm-unittest` → builds successfully with Go 1.26.4
- [ ] CI: `go test ./pkg/unittest/...` passes

Made with [Cursor](https://cursor.com)