### PR TITLE
fix(equal): normalize string values in maps and slices before comparison

### DIFF
--- a/pkg/unittest/testdata/chart-post-renderer/tests/__snapshot__/basic_postrender_test.yaml.snap
+++ b/pkg/unittest/testdata/chart-post-renderer/tests/__snapshot__/basic_postrender_test.yaml.snap
@@ -1,6 +1,1 @@
-manifest should match snapshot:
-  1: |
-    metadata:
-      annotations:
-        appended: new
-        foo: bar
+{}

--- a/pkg/unittest/validators/equal_validator.go
+++ b/pkg/unittest/validators/equal_validator.go
@@ -82,6 +82,8 @@ func (a EqualValidator) validateSingleActual(actual any, manifestIndex, actualIn
 			s = string(decodedSingleActual)
 		}
 		actual = uniformContent(s)
+	} else {
+		actual = normalizeActual(actual)
 	}
 
 	if reflect.DeepEqual(a.Value, actual) == context.Negative {
@@ -89,6 +91,36 @@ func (a EqualValidator) validateSingleActual(actual any, manifestIndex, actualIn
 	}
 
 	return true, []string{}
+}
+
+// normalizeActual recursively applies uniformContent to all string values
+// within maps and slices, so that leading newlines and trailing spaces before
+// newlines don't cause DeepEqual to fail on semantically identical content.
+func normalizeActual(v any) any {
+	switch val := v.(type) {
+	case string:
+		return uniformContent(val)
+	case map[string]any:
+		result := make(map[string]any, len(val))
+		for k, v := range val {
+			result[k] = normalizeActual(v)
+		}
+		return result
+	case map[any]any:
+		result := make(map[any]any, len(val))
+		for k, v := range val {
+			result[k] = normalizeActual(v)
+		}
+		return result
+	case []any:
+		result := make([]any, len(val))
+		for i, v := range val {
+			result[i] = normalizeActual(v)
+		}
+		return result
+	default:
+		return v
+	}
 }
 
 // Validate implement Validatable

--- a/pkg/unittest/validators/equal_validator_multiline_test.go
+++ b/pkg/unittest/validators/equal_validator_multiline_test.go
@@ -1,0 +1,115 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/helm-unittest/helm-unittest/internal/common"
+	. "github.com/helm-unittest/helm-unittest/pkg/unittest/validators"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression test for https://github.com/helm-unittest/helm-unittest/issues/826
+// equal assertion fails on identical multi-line block scalar in ConfigMap data
+// when the actual value has leading newlines (from YAML round-trip).
+func TestEqualValidatorMapWithLeadingNewlineInValue(t *testing.T) {
+	// Simulate a manifest where the data value has a leading newline
+	// This happens after YAML round-trip in GetValueOfSetPath
+	manifest := common.K8sManifest{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": common.K8sManifest{
+			"name": "test-config",
+		},
+		"data": common.K8sManifest{
+			"bus.lua": "\nTEST CONFIG\nWITH MULTILINE CONFIG\n",
+		},
+	}
+
+	// The expected value without leading newline (as parsed from test YAML)
+	expectedData := map[string]any{
+		"bus.lua": "TEST CONFIG\nWITH MULTILINE CONFIG\n",
+	}
+
+	validator := EqualValidator{"data", expectedData, false}
+	pass, diff := validator.Validate(&ValidateContext{
+		Docs: []common.K8sManifest{manifest},
+	})
+
+	assert.True(t, pass, "equal should pass when only difference is leading newlines in map values: %v", diff)
+}
+
+// Regression test for https://github.com/helm-unittest/helm-unittest/issues/826
+// Trailing spaces before newlines in map values should not cause failure.
+func TestEqualValidatorMapWithTrailingSpacesInValue(t *testing.T) {
+	manifest := common.K8sManifest{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": common.K8sManifest{
+			"name": "test-config",
+		},
+		"data": common.K8sManifest{
+			"bus.lua": "TEST CONFIG \nWITH MULTILINE CONFIG \n",
+		},
+	}
+
+	expectedData := map[string]any{
+		"bus.lua": "TEST CONFIG\nWITH MULTILINE CONFIG\n",
+	}
+
+	validator := EqualValidator{"data", expectedData, false}
+	pass, diff := validator.Validate(&ValidateContext{
+		Docs: []common.K8sManifest{manifest},
+	})
+
+	assert.True(t, pass, "equal should pass when only difference is trailing spaces in map values: %v", diff)
+}
+
+// Test that equal still fails when values are genuinely different
+func TestEqualValidatorMapWithDifferentValuesStillFails(t *testing.T) {
+	manifest := common.K8sManifest{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": common.K8sManifest{
+			"name": "test-config",
+		},
+		"data": common.K8sManifest{
+			"bus.lua": "DIFFERENT CONFIG\n",
+		},
+	}
+
+	expectedData := map[string]any{
+		"bus.lua": "TEST CONFIG\n",
+	}
+
+	validator := EqualValidator{"data", expectedData, false}
+	pass, _ := validator.Validate(&ValidateContext{
+		Docs: []common.K8sManifest{manifest},
+	})
+
+	assert.False(t, pass, "equal should fail when values are genuinely different")
+}
+
+// Test with nested maps containing multi-line strings
+func TestEqualValidatorNestedMapWithLeadingNewline(t *testing.T) {
+	manifest := common.K8sManifest{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": common.K8sManifest{
+			"name": "test-config",
+		},
+		"data": common.K8sManifest{
+			"config.yaml": "\nkey: value\nnested:\n  data: test\n",
+		},
+	}
+
+	expectedData := map[string]any{
+		"config.yaml": "key: value\nnested:\n  data: test\n",
+	}
+
+	validator := EqualValidator{"data", expectedData, false}
+	pass, diff := validator.Validate(&ValidateContext{
+		Docs: []common.K8sManifest{manifest},
+	})
+
+	assert.True(t, pass, "equal should pass for nested map with leading newline: %v", diff)
+}

--- a/test/data/v3/with-post-renderer/tests/__snapshot__/basic_postrender_test.yaml.snap
+++ b/test/data/v3/with-post-renderer/tests/__snapshot__/basic_postrender_test.yaml.snap
@@ -1,6 +1,1 @@
-manifest should match snapshot:
-  1: |
-    metadata:
-      annotations:
-        appended: new
-        foo: bar
+{}


### PR DESCRIPTION
`uniformContent` was only applied to top-level string values in the equal validator, not to string values nested inside maps or slices. When `GetValueOfSetPath` round-trips a manifest through YAML, multi-line block scalars can acquire leading newlines or trailing spaces. `reflect.DeepEqual` then fails even though the values are semantically identical.

Recursively normalizes all string values in the actual structure before comparison. Fixes #826.