### PR TITLE
Fix documentSelector not working when multiple templates are used

### DIFF
--- a/pkg/unittest/valueutils/documentselector.go
+++ b/pkg/unittest/valueutils/documentselector.go
@@ -41,21 +41,26 @@ func (ds DocumentSelector) SelectDocuments(documentsByTemplate map[string][]comm
 	for template, manifests := range documentsByTemplate {
 		filteredManifests, err := ds.selectDocuments(manifests)
 
-		filteredManifestsCount := len(filteredManifests)
-		matchingDocumentsCount += filteredManifestsCount
-
 		if err != nil {
 			return map[string][]common.K8sManifest{}, err
 		}
+
+		filteredManifestsCount := len(filteredManifests)
+		matchingDocumentsCount += filteredManifestsCount
 
 		if !ds.MatchMany && matchingDocumentsCount > 1 {
 			return map[string][]common.K8sManifest{}, errors.New("multiple indexes found")
 		}
 
-		if filteredManifestsCount > 0 || !ds.SkipEmptyTemplates {
+		if filteredManifestsCount > 0 {
 			matchingDocuments[template] = filteredManifests
 		}
 	}
+
+	if matchingDocumentsCount == 0 && !ds.SkipEmptyTemplates {
+		return map[string][]common.K8sManifest{}, errors.New("document not found")
+	}
+
 	return matchingDocuments, nil
 }
 
@@ -77,11 +82,7 @@ func (ds DocumentSelector) selectDocuments(docs []common.K8sManifest) ([]common.
 		}
 	}
 
-	if ds.SkipEmptyTemplates || len(selectedDocs) > 0 {
-		return selectedDocs, nil
-	}
-
-	return selectedDocs, errors.New("document not found")
+	return selectedDocs, nil
 }
 
 func (ds DocumentSelector) isMatchingSelector(doc common.K8sManifest) (bool, error) {

--- a/pkg/unittest/valueutils/documentselector_test.go
+++ b/pkg/unittest/valueutils/documentselector_test.go
@@ -178,13 +178,32 @@ func TestFindDocumentIndicesMatchManyAndSkipEmptyTemplatesOk(t *testing.T) {
 	a.Equal(expectedManifests, actualManifests)
 }
 
-func TestFindDocumentIndicesMatchManyAndDontSkipEmptyTemplatesNOk(t *testing.T) {
+func TestFindDocumentIndicesMatchManyAndDontSkipEmptyTemplatesOk(t *testing.T) {
+	a := assert.New(t)
+	expectedManifests := map[string][]common.K8sManifest{
+		"secondTemplate": {parseManifest(secondTemplateDocToTestIndex0), parseManifest(secondTemplateDocToTestIndex1)},
+	}
+
+	selector := DocumentSelector{
+		Path:               "metadata.namespace",
+		Value:              "foo",
+		MatchMany:          true,
+		SkipEmptyTemplates: false,
+	}
+
+	actualManifests, err := selector.SelectDocuments(createMultiTemplateMultiManifest())
+
+	a.Nil(err)
+	a.Equal(expectedManifests, actualManifests)
+}
+
+func TestFindDocumentIndicesMatchManyAndDontSkipEmptyTemplatesNoDocumentNOk(t *testing.T) {
 	a := assert.New(t)
 	expectedManifests := map[string][]common.K8sManifest{}
 
 	selector := DocumentSelector{
 		Path:               "metadata.namespace",
-		Value:              "foo",
+		Value:              "baz",
 		MatchMany:          true,
 		SkipEmptyTemplates: false,
 	}


### PR DESCRIPTION
### Description

Fixes #781

This PR resolves an issue where the `documentSelector` functionality prematurely aborted and returned a `document not found` error if *any* rendered template did not contain a document matching the selector. 

In a multi-template chart/suite (the standard way of writing unit tests), templates often render different resource types (e.g. `deployment.yaml` and `secret.yaml`). When asserting on a single resource type using `documentSelector`, templates for other resource types will naturally yield no matches. 

### Changes

1. **`pkg/unittest/valueutils/documentselector.go`**:
   - Refactored `SelectDocuments` and `selectDocuments` to only fail with a `document not found` error if **no** templates matched the selector across the entire suite (and `skipEmptyTemplates` is `false`).
   - Prevented unmatched templates from being added to the returned results map to avoid empty assertions failing downstream.
2. **`pkg/unittest/valueutils/documentselector_test.go`**:
   - Updated `TestFindDocumentIndicesMatchManyAndDontSkipEmptyTemplatesOk` to verify that matching a subset of templates does not fail when `skipEmptyTemplates: false`.
   - Added a new test `TestFindDocumentIndicesMatchManyAndDontSkipEmptyTemplatesNoDocumentNOk` to verify that `document not found` is still thrown if the document is completely absent.