### PR TITLE
fix: encode Secret stringData into data for kubernetesProvider (#768)

### DIFF
--- a/DOCUMENT.md
+++ b/DOCUMENT.md
@@ -93,7 +93,7 @@ tests:
 
 - **kubernetesProvider**: *object, optional*. Define Kubernetes resources to fake.
   - **scheme**: *object*. Define the Kubernetes schema to fake
-  - **objects**: *array of objects*. Define the Kubernetes objects to fake
+  - **objects**: *array of objects*. Define the Kubernetes objects to fake. A `v1/Secret` may use `stringData`, which is base64 encoded into `data` and dropped, just like the api-server does.
 
 - **skip**: *object, optional*. Marks the test suite as having been skipped. Execution will continue at the next suite.
   - **reason**: *string, required*. Define the reason for skipping. Marks all tests as skipped. Do not set **minimumVersion** if you set this.
@@ -185,7 +185,7 @@ tests:
 
 - **kubernetesProvider**: *object, optional*. Define Kubernetes resources to fake.
   - **scheme**: *object, optional*. Define the Kubernetes schema to fake
-  - **objects**: *array of objects*. Define the Kubernetes objects to fake
+  - **objects**: *array of objects*. Define the Kubernetes objects to fake. A `v1/Secret` may use `stringData`, which is base64 encoded into `data` and dropped, just like the api-server does.
 
 - **skip**: *object, optional*. Marks the test as having been skipped. Execution will continue at the next test.
   - **reason**: *string, required*. Define the reason for skipping. If all tests skipped, marks 'suite' as skipped.

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithFakeK8sClient
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithFakeK8sClient
@@ -5,13 +5,14 @@
  PASS  	../../test/data/v3/with-k8s-fake-client/tests/lookup_crd_noprovider_test.yaml
  PASS  	../../test/data/v3/with-k8s-fake-client/tests/lookup_crd_test.yaml
  PASS  	../../test/data/v3/with-k8s-fake-client/tests/lookup_noprovider_test.yaml
+ PASS  	../../test/data/v3/with-k8s-fake-client/tests/lookup_secret_test.yaml
  PASS  	../../test/data/v3/with-k8s-fake-client/tests/lookup_test.yaml
 
 
 Charts:      1 passed, 1 total
-Test Suites: 4 passed, 4 total
-Tests:       5 passed, 5 total
-Snapshot:    4 passed, 4 total
+Test Suites: 5 passed, 5 total
+Tests:       7 passed, 7 total
+Snapshot:    5 passed, 5 total
 Time:        XX.XXXms
 
 

--- a/pkg/unittest/k8s_fake_client.go
+++ b/pkg/unittest/k8s_fake_client.go
@@ -1,6 +1,9 @@
 package unittest
 
 import (
+	"encoding/base64"
+	"fmt"
+	"maps"
 	"path"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -34,8 +37,51 @@ func convertRuntimeObject(input []map[string]any) []runtime.Object {
 	result := make([]runtime.Object, len(input))
 
 	for k, v := range input {
-		result[k] = &unstructured.Unstructured{Object: v}
+		result[k] = &unstructured.Unstructured{Object: normalizeSecret(v)}
 	}
 
 	return result
+}
+
+// normalizeSecret mimics what the api-server does when a v1/Secret is stored:
+// the write-only stringData is base64 encoded into data and dropped.
+func normalizeSecret(object map[string]any) map[string]any {
+	if object["kind"] != "Secret" || object["apiVersion"] != "v1" {
+		return object
+	}
+
+	rawStringData, found := object["stringData"]
+	if !found {
+		return object
+	}
+	stringData, ok := rawStringData.(map[string]any)
+	if !ok && rawStringData != nil {
+		return object // nothing we can encode, better than dropping data
+	}
+
+	data := map[string]any{}
+	if existing, ok := object["data"].(map[string]any); ok {
+		maps.Copy(data, existing)
+	}
+	for key, value := range stringData {
+		data[key] = base64.StdEncoding.EncodeToString([]byte(stringify(value)))
+	}
+
+	// copy, the test definition is shared between test jobs
+	normalized := maps.Clone(object)
+	delete(normalized, "stringData")
+	normalized["data"] = data
+
+	return normalized
+}
+
+// stringify keeps non-string scalars such as `port: 8080` usable.
+func stringify(value any) string {
+	if value == nil {
+		return ""
+	}
+	if s, ok := value.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", value)
 }

--- a/pkg/unittest/k8s_fake_client_test.go
+++ b/pkg/unittest/k8s_fake_client_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/helm-unittest/helm-unittest/pkg/unittest"
@@ -43,4 +44,103 @@ func TestKubernetesFakeClientProvider(t *testing.T) {
 
 	_, err = client.Namespace("default").Get(context.Background(), "notexisting", v1.GetOptions{})
 	assert.Error(t, err)
+}
+
+func secretClientFor(t *testing.T, secret map[string]any) *unstructured.Unstructured {
+	t.Helper()
+
+	k := KubernetesFakeClientProvider{
+		Scheme:  map[string]KubernetesFakeKindProps{"v1/Secret": {Gvr: schema.GroupVersionResource{Resource: "secrets", Version: "v1"}, Namespaced: true}},
+		Objects: []map[string]any{secret},
+	}
+
+	client, _, err := k.GetClientFor("v1", "Secret")
+	assert.NoError(t, err)
+
+	item, err := client.Namespace("default").Get(context.Background(), "unittest", v1.GetOptions{})
+	assert.NoError(t, err)
+
+	return item
+}
+
+func TestKubernetesFakeClientProviderSecretStringDataIsEncoded(t *testing.T) {
+	secret := newMap("v1", "Secret", "default", "unittest")
+	secret["stringData"] = map[string]any{"whatever": "whatever value", "port": 8080}
+
+	item := secretClientFor(t, secret)
+
+	assert.Equal(t, map[string]any{
+		"whatever": "d2hhdGV2ZXIgdmFsdWU=",
+		"port":     "ODA4MA==",
+	}, item.Object["data"])
+	assert.NotContains(t, item.Object, "stringData")
+
+	// the original test definition must not be mutated
+	assert.Contains(t, secret, "stringData")
+	assert.NotContains(t, secret, "data")
+}
+
+func TestKubernetesFakeClientProviderSecretStringDataOverridesData(t *testing.T) {
+	secret := newMap("v1", "Secret", "default", "unittest")
+	secret["data"] = map[string]any{"kept": "a2VwdA==", "overridden": "b2xk"}
+	secret["stringData"] = map[string]any{"overridden": "new"}
+
+	item := secretClientFor(t, secret)
+
+	assert.Equal(t, map[string]any{
+		"kept":       "a2VwdA==",
+		"overridden": "bmV3",
+	}, item.Object["data"])
+}
+
+func TestKubernetesFakeClientProviderSecretWithEmptyStringDataDropsTheField(t *testing.T) {
+	secret := newMap("v1", "Secret", "default", "unittest")
+	secret["data"] = map[string]any{"kept": "a2VwdA=="}
+	secret["stringData"] = nil
+
+	item := secretClientFor(t, secret)
+
+	assert.Equal(t, map[string]any{"kept": "a2VwdA=="}, item.Object["data"])
+	assert.NotContains(t, item.Object, "stringData")
+}
+
+func TestKubernetesFakeClientProviderSecretWithUnexpectedStringDataIsUntouched(t *testing.T) {
+	secret := newMap("v1", "Secret", "default", "unittest")
+	secret["data"] = map[string]any{"kept": "a2VwdA=="}
+	secret["stringData"] = "not a map"
+
+	item := secretClientFor(t, secret)
+
+	assert.Equal(t, map[string]any{"kept": "a2VwdA=="}, item.Object["data"])
+	assert.Equal(t, "not a map", item.Object["stringData"])
+}
+
+func TestKubernetesFakeClientProviderSecretWithoutStringDataIsUntouched(t *testing.T) {
+	secret := newMap("v1", "Secret", "default", "unittest")
+	secret["data"] = map[string]any{"whatever": "d2hhdGV2ZXIgdmFsdWU="}
+
+	item := secretClientFor(t, secret)
+
+	assert.Equal(t, map[string]any{"whatever": "d2hhdGV2ZXIgdmFsdWU="}, item.Object["data"])
+}
+
+func TestKubernetesFakeClientProviderStringDataOnlyConvertedForCoreSecret(t *testing.T) {
+	stringData := map[string]any{"whatever": "whatever value"}
+
+	custom := newMap("example.com/v1", "Secret", "default", "unittest")
+	custom["stringData"] = stringData
+
+	k := KubernetesFakeClientProvider{
+		Scheme:  map[string]KubernetesFakeKindProps{"example.com/v1/Secret": {Gvr: schema.GroupVersionResource{Group: "example.com", Resource: "secrets", Version: "v1"}, Namespaced: true}},
+		Objects: []map[string]any{custom},
+	}
+
+	client, _, err := k.GetClientFor("example.com/v1", "Secret")
+	assert.NoError(t, err)
+
+	item, err := client.Namespace("default").Get(context.Background(), "unittest", v1.GetOptions{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, stringData, item.Object["stringData"])
+		assert.NotContains(t, item.Object, "data")
+	}
 }

--- a/test/data/v3/with-k8s-fake-client/templates/lookup_secret.yaml
+++ b/test/data/v3/with-k8s-fake-client/templates/lookup_secret.yaml
@@ -1,0 +1,14 @@
+---
+{{- $mock := (lookup "v1" "Secret" "default" "mock-secret") }}
+{{- $all := (lookup "v1" "Secret" "default" "") }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: testsecret
+stringData:
+  from_string_data: {{ dig "data" "plain" "" $mock | b64dec | quote }}
+  from_data: {{ dig "data" "encoded" "" $mock | b64dec | quote }}
+  overridden: {{ dig "data" "overridden" "" $mock | b64dec | quote }}
+  string_data_is_dropped: {{ not (hasKey $mock "stringData") | quote }}
+  secrets_found: {{ len (dig "items" (list) $all) | quote }}

--- a/test/data/v3/with-k8s-fake-client/tests/__snapshot__/lookup_secret_test.yaml.snap
+++ b/test/data/v3/with-k8s-fake-client/tests/__snapshot__/lookup_secret_test.yaml.snap
@@ -1,0 +1,13 @@
+should base64 encode stringData into data, like the api-server does:
+  1: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: testsecret
+    stringData:
+      from_data: encoded value
+      from_string_data: plain value
+      overridden: new value
+      secrets_found: "1"
+      string_data_is_dropped: "true"
+    type: Opaque

--- a/test/data/v3/with-k8s-fake-client/tests/lookup_secret_test.yaml
+++ b/test/data/v3/with-k8s-fake-client/tests/lookup_secret_test.yaml
@@ -1,0 +1,54 @@
+templates:
+  - templates/lookup_secret.yaml
+kubernetesProvider:
+  scheme:
+    "v1/Secret":
+      gvr:
+        version: "v1"
+        resource: "secrets"
+      namespaced: true
+  objects:
+    - kind: Secret
+      apiVersion: v1
+      metadata:
+        name: mock-secret
+        namespace: default
+      data:
+        encoded: ZW5jb2RlZCB2YWx1ZQ==
+        overridden: b2xkIHZhbHVl
+      stringData:
+        plain: plain value
+        overridden: new value
+tests:
+  - it: should base64 encode stringData into data, like the api-server does
+    asserts:
+      - matchSnapshot: {}
+      - equal:
+          path: stringData
+          value:
+            from_string_data: plain value
+            from_data: encoded value
+            overridden: new value
+            string_data_is_dropped: "true"
+            secrets_found: "1"
+
+  - it: should leave the suite level object untouched for the next test
+    kubernetesProvider:
+      objects:
+        - kind: Secret
+          apiVersion: v1
+          metadata:
+            name: extra-secret
+            namespace: default
+          stringData:
+            other: other value
+    asserts:
+      - equal:
+          path: stringData.from_string_data
+          value: plain value
+      - equal:
+          path: stringData.string_data_is_dropped
+          value: "true"
+      - equal:
+          path: stringData.secrets_found
+          value: "2"


### PR DESCRIPTION
Fixes #768

### Problem

`convertRuntimeObject` hands the objects from a `kubernetesProvider` block to the fake dynamic client verbatim. A mocked `v1/Secret` declared with `stringData` therefore keeps that field instead of exposing base64 encoded `data`, which a real cluster would never do.

Reproduced on `main` (33c48ca) with the chart from the issue, same error as reported:

```
 FAIL  	tests/secret_test.yaml
	- should match
		Error: template: chart/templates/secret.yaml:8:45: executing "chart/templates/secret.yaml" at <"mock-secret-name">: nil pointer evaluating interface {}.whatever
```

### What the api-server actually does

From `kubectl explain secret.stringData`:

> stringData allows specifying non-binary secret data in string form. It is provided as a **write-only** input field for convenience. All keys and values are **merged into the data field on write, overwriting any existing values**. The stringData field is **never output when reading from the API**.

That sentence dictates all three rules implemented here.

### Fix

`normalizeSecret` applies those rules to core `v1/Secret` objects only:

- `stringData` values are base64 encoded into `data`
- a key present in both takes its value from `stringData`
- the `stringData` field is dropped

Everything else returns the very same map untouched: other kinds, secrets in a non-core group (e.g. `example.com/v1`), secrets without `stringData`, and a `stringData` of an unexpected type. The object is copied rather than mutated, because `polishKubernetesProviderSettings` appends the suite level objects into every test job, so those maps are shared.

Non-string scalars (`port: 8080`) are stringified before encoding rather than silently becoming `<nil>`.

### Behaviour change

A test that mocks a Secret with `stringData` and then reads `.stringData` back in a template will now get nothing, because the field no longer exists on the faked object. The reporter mentions relying on this as a workaround, so it is worth calling out — though what it relies on is exactly the behaviour the API contract rules out ("never output when reading from the API"), and it fails loudly rather than silently. Happy to keep both fields populated instead if you would rather not break it; that is one line.

### Verification

Only one line of existing code changes (`Object: v` → `Object: normalizeSecret(v)`); everything else is additive.

- Unit tests: encoding, `stringData` winning over `data`, empty/`null` `stringData`, unexpected `stringData` type, secrets without `stringData`, a non-core `Secret` kind staying untouched, and the original test definition not being mutated.
- End-to-end fixture in `test/data/v3/with-k8s-fake-client` covering the real `lookup` path, both the single-object and the list form, plus a second test proving a suite level object is not contaminated by the test that ran before it. Verified it fails against `main` (`from_string_data: ""`, `overridden: old value`, `string_data_is_dropped: "false"`) and passes here.
- No existing snapshot content changed — the only deltas in `.snapshots/TestV3RunnerOkWithFakeK8sClient` are the suite/test counters, regenerated with `UPDATE_SNAPSHOTS=true` as CONTRIBUTING describes.
- `gofmt -l`, `go vet ./...` and `go test ./...` clean.

`DOCUMENT.md` gets a one-line note in both `kubernetesProvider` sections, which also covers a little of what you mentioned about the provider being under-documented.
