### PR TITLE
feat: add debug option on test suite and test job level

### DIFF
--- a/DOCUMENT.md
+++ b/DOCUMENT.md
@@ -59,6 +59,7 @@ postRenderer:
     - "eval"
     - '.metadata.annotations.appended="new"'
     - "-"
+debug: true
 tests:
   - it: should test something
     ...
@@ -103,6 +104,8 @@ tests:
   - **cmd**: *string, required*. The full path to the command to invoke, or just its name if it's on `$PATH`.
   - **args**: *array of strings*. Command-line arguments to pass to the above `cmd`.
 
+- **debug**: *bool, optional*. When set to `true`, prints the rendered manifests of **every** test job in this suite to stdout, to help diagnose failing tests. Defaults to `false`. The output is taken after any `postRenderer` has been applied, so it shows exactly what the assertions validate. Individual test jobs can enable this on their own instead, check [Test Job](#test-job).
+
 - **tests**: *array of test job, required*. Where you define your test jobs to run, check [Test Job](#test-job).
 
 ## Test Job
@@ -146,6 +149,7 @@ tests:
         - "eval"
         - '.metadata.annotations.appended="new"'
         - "-"
+    debug: true
     asserts:
       - equal:
           path: metadata.name
@@ -193,6 +197,8 @@ tests:
 - **postRenderer**: *object, optional*. A helm [post-renderer](https://helm.sh/docs/topics/advanced/#post-rendering) to apply after chart rendering but before validation.
     - **cmd**: *string, required*. The full path to the command to invoke, or just its name if it's on `$PATH`.
     - **args**: *array of strings*. Command-line arguments to pass to the above `cmd`.
+
+- **debug**: *bool, optional*. When set to `true`, prints the rendered manifests of **this** test job to stdout, to help diagnose a failing test. Defaults to `false`. The output is taken after any `postRenderer` has been applied, so it shows exactly what the assertions validate. Enabling `debug` on the suite turns this on for every test job, but a test job never disables what the suite enabled.
 
 - **asserts**: *array of assertion, required*. The assertions to validate the rendered chart, check [Assertion](#assertion).
 

--- a/pkg/unittest/.snapshots/TestV3RunJobOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobOk
@@ -28,5 +28,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithAssertionFail
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithAssertionFail
@@ -50,5 +50,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithAssertionFailFast
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithAssertionFailFast
@@ -31,5 +31,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithCapabilitySettings
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithCapabilitySettings
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithChartSettings
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithChartSettings
@@ -28,5 +28,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithFailingTemplate
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithFailingTemplate
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithNoCapabilitySettingsEmptyDoc
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithNoCapabilitySettingsEmptyDoc
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithReleaseSettings
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithReleaseSettings
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithRenderPathOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithRenderPathOk
@@ -28,5 +28,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithSchema
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithSchema
@@ -20,5 +20,6 @@ with-schema:
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithSchemaAndNullValue
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithSchemaAndNullValue
@@ -20,5 +20,6 @@ with-schema:
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithSchemaOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithSchemaOk
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithSkipSchemaValidation
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithSkipSchemaValidation
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithSkipSchemaValidationInvalidValues
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithSkipSchemaValidationInvalidValues
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTestJobDocumentSelectorOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTestJobDocumentSelectorOk
@@ -28,5 +28,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTestJobTemplateOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTestJobTemplateOk
@@ -28,5 +28,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTestJobTemplatesOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTestJobTemplatesOk
@@ -39,5 +39,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTestMissingRequiredValueOk
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTestMissingRequiredValueOk
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithTooLongReleaseName
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithTooLongReleaseName
@@ -19,5 +19,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithValueSet
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithValueSet
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunJobWithValuesFile
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithValuesFile
@@ -17,5 +17,6 @@
       CustomInfo: (string) ""
     })
   },
-  Duration: (time.Duration) 0s
+  Duration: (time.Duration) 0s,
+  DebugOutput: (string) ""
 })

--- a/pkg/unittest/.snapshots/TestV3RunSuiteNameOverrideFail
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteNameOverrideFail
@@ -25,7 +25,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWhenFail
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWhenFail
@@ -39,7 +39,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWhenPass
@@ -36,7 +36,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithMultipleTemplatesWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithMultipleTemplatesWhenPass
@@ -80,7 +80,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithNoAssertsShouldFail
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithNoAssertsShouldFail
@@ -14,7 +14,8 @@
       ExecError: (error) <nil>,
       AssertsResult: ([]*results.AssertionResult) {
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithOverridesWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithOverridesWhenPass
@@ -36,7 +36,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsTrimmingWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsTrimmingWhenPass
@@ -25,7 +25,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsWhenPass
@@ -36,7 +36,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsWithAliasWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithSubChartsWithAliasWhenPass
@@ -36,7 +36,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     }),
     (*results.TestJobResult)({
       DisplayName: (string) (len=23) "should no pvc for alias",
@@ -57,7 +58,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunSuiteWithSubfolderWhenPass
+++ b/pkg/unittest/.snapshots/TestV3RunSuiteWithSubfolderWhenPass
@@ -36,7 +36,8 @@
           CustomInfo: (string) ""
         })
       },
-      Duration: (time.Duration) 0s
+      Duration: (time.Duration) 0s,
+      DebugOutput: (string) ""
     })
   },
   SnapshotCounting: (struct { Total uint; Failed uint; Created uint; Vanished uint }) {

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithPostRenderer
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithPostRenderer
@@ -4,6 +4,32 @@
 
  PASS  	../../test/data/v3/with-post-renderer/tests/basic_no_postrender_test.yaml
  PASS  	../../test/data/v3/with-post-renderer/tests/basic_postrender_test.yaml
+	- manifest should match snapshot
+		
+#### file: with-post-renderer/templates/basic.yaml
+		---
+		metadata:
+		  annotations:
+		    foo: "bar"
+		    appended: new
+
+	- manifest should include an extra annotation due to suite yq post-renderer
+		
+#### file: with-post-renderer/templates/basic.yaml
+		---
+		metadata:
+		  annotations:
+		    foo: "bar"
+		    appended: new
+
+	- manifest should overwrite existing annotation due to test-job yq post-renderer
+		
+#### file: with-post-renderer/templates/basic.yaml
+		---
+		metadata:
+		  annotations:
+		    foo: "baz"
+
 
 
 Charts:      1 passed, 1 total

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -1,9 +1,6 @@
 package unittest
 
 import (
-	"io"
-	"os"
-
 	"github.com/helm-unittest/helm-unittest/internal/common"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/validators"
@@ -21,16 +18,6 @@ type TestConfig struct {
 	postRenderer           PostRendererConfig
 	includeCrds            bool
 	debug                  bool
-	debugWriter            io.Writer
-}
-
-// debugWriterOrDefault returns the writer debug output should be written to,
-// falling back to stdout when none was configured.
-func (c TestConfig) debugWriterOrDefault() io.Writer {
-	if c.debugWriter == nil {
-		return os.Stdout
-	}
-	return c.debugWriter
 }
 
 func NewTestConfig(chart *v3chart.Chart, cache *snapshot.Cache, options ...func(*TestConfig)) *TestConfig {
@@ -104,13 +91,6 @@ func WithSkipSchemaValidation(skip bool) LoadTestOptionsFunc {
 func WithDebug(debug bool) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
 		c.debug = debug
-	}
-}
-
-// WithDebugWriter sets where debug output is written to, defaulting to stdout.
-func WithDebugWriter(writer io.Writer) LoadTestOptionsFunc {
-	return func(c *TestConfig) {
-		c.debugWriter = writer
 	}
 }
 

--- a/pkg/unittest/models.go
+++ b/pkg/unittest/models.go
@@ -1,6 +1,9 @@
 package unittest
 
 import (
+	"io"
+	"os"
+
 	"github.com/helm-unittest/helm-unittest/internal/common"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/snapshot"
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/validators"
@@ -17,6 +20,17 @@ type TestConfig struct {
 	isSkipSchemaValidation bool
 	postRenderer           PostRendererConfig
 	includeCrds            bool
+	debug                  bool
+	debugWriter            io.Writer
+}
+
+// debugWriterOrDefault returns the writer debug output should be written to,
+// falling back to stdout when none was configured.
+func (c TestConfig) debugWriterOrDefault() io.Writer {
+	if c.debugWriter == nil {
+		return os.Stdout
+	}
+	return c.debugWriter
 }
 
 func NewTestConfig(chart *v3chart.Chart, cache *snapshot.Cache, options ...func(*TestConfig)) *TestConfig {
@@ -29,6 +43,7 @@ func NewTestConfig(chart *v3chart.Chart, cache *snapshot.Cache, options ...func(
 		isSkipSchemaValidation: false,
 		postRenderer:           PostRendererConfig{},
 		includeCrds:            false,
+		debug:                  false,
 	}
 	for _, option := range options {
 		option(config)
@@ -81,6 +96,21 @@ func WithIncludeCrds(includeCrds bool) LoadTestOptionsFunc {
 func WithSkipSchemaValidation(skip bool) LoadTestOptionsFunc {
 	return func(c *TestConfig) {
 		c.isSkipSchemaValidation = skip
+	}
+}
+
+// WithDebug enables printing of the rendered manifests for every test job in
+// the suite. Individual test jobs can opt in on their own via their debug field.
+func WithDebug(debug bool) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		c.debug = debug
+	}
+}
+
+// WithDebugWriter sets where debug output is written to, defaulting to stdout.
+func WithDebugWriter(writer io.Writer) LoadTestOptionsFunc {
+	return func(c *TestConfig) {
+		c.debugWriter = writer
 	}
 }
 

--- a/pkg/unittest/results/test_job_result.go
+++ b/pkg/unittest/results/test_job_result.go
@@ -17,11 +17,32 @@ type TestJobResult struct {
 	ExecError     error
 	AssertsResult []*AssertionResult
 	Duration      time.Duration
+	// DebugOutput holds the rendered manifests to show when debug is enabled for
+	// this test job. It is intentionally left out of Stringify, so it does not end
+	// up in the xml reports.
+	DebugOutput string
+}
+
+// printDebugOutput prints the rendered manifests collected while running the job.
+// The name is only printed when the rest of print doesn't, to avoid repeating it.
+func (tjr TestJobResult) printDebugOutput(printer *printer.Printer, withName bool) {
+	if tjr.DebugOutput == "" {
+		return
+	}
+	if withName {
+		printer.Println(printer.Faint("- %s", tjr.DisplayName), 1)
+	}
+	for line := range strings.SplitSeq(strings.TrimRight(tjr.DebugOutput, "\n"), "\n") {
+		printer.Println(printer.Faint("%s", line), 2)
+	}
+	printer.Println("", 0)
 }
 
 // print the information to the console.
 func (tjr TestJobResult) print(printer *printer.Printer, verbosity int) {
 	if tjr.Passed {
+		// nothing else is printed for a passing job, so label the debug output
+		tjr.printDebugOutput(printer, true)
 		return
 	}
 
@@ -30,16 +51,19 @@ func (tjr TestJobResult) print(printer *printer.Printer, verbosity int) {
 		msg += printer.WarningLabel("SKIPPED")
 		msg += printer.Warning(" '%s'", tjr.DisplayName)
 		printer.Println(msg, 1)
+		tjr.printDebugOutput(printer, false)
 		return
 	}
 
 	if tjr.ExecError != nil {
 		printer.Println(printer.Highlight("- %s", tjr.DisplayName), 1)
+		tjr.printDebugOutput(printer, false)
 		printer.Println(printer.Highlight("Error: %s\n", tjr.ExecError.Error()), 2)
 		return
 	}
 
 	printer.Println(printer.Danger("- %s\n", tjr.DisplayName), 1)
+	tjr.printDebugOutput(printer, false)
 	for _, assertResult := range tjr.AssertsResult {
 		assertResult.print(printer, verbosity)
 	}

--- a/pkg/unittest/results/test_job_result_test.go
+++ b/pkg/unittest/results/test_job_result_test.go
@@ -3,6 +3,7 @@ package results
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/printer"
@@ -85,4 +86,93 @@ func TestStringify_WithExecErrorAndAssertions(t *testing.T) {
 	expected += "\t\t - asserts[0] `` fail \n\t\t\t assertion error 2 \n"
 	result := tjr.Stringify()
 	assert.Equal(t, expected, result)
+}
+
+// test DebugOutput
+func TestPrint_DebugOutputShownWhenJobFailed(t *testing.T) {
+	flag := false
+	pr := printer.NewPrinter(new(bytes.Buffer), &flag)
+
+	tjr := TestJobResult{
+		DisplayName: "some job",
+		Passed:      false,
+		DebugOutput: "#### file: chart/templates/deployment.yaml\nkind: Deployment\n",
+		AssertsResult: []*AssertionResult{
+			{Index: 0, FailInfo: []string{"expected", "actual"}, AssertType: "equal"},
+		},
+	}
+
+	tjr.print(pr, 1)
+	output := fmt.Sprintf("%s", pr.Writer)
+	a := assert.New(t)
+	a.Contains(output, "kind: Deployment", "debug output should accompany the failure")
+	a.Contains(output, "asserts[0]", "the assertion failure must still be printed")
+}
+
+func TestPrint_DebugOutputShownWhenJobPassed(t *testing.T) {
+	flag := false
+	pr := printer.NewPrinter(new(bytes.Buffer), &flag)
+
+	tjr := TestJobResult{
+		DisplayName: "some job",
+		Passed:      true,
+		DebugOutput: "#### file: chart/templates/deployment.yaml\nkind: Deployment\n",
+	}
+
+	tjr.print(pr, 1)
+	output := fmt.Sprintf("%s", pr.Writer)
+	a := assert.New(t)
+	// debug was explicitly asked for, so it must survive the passing-job early return
+	a.Contains(output, "kind: Deployment", "debug output should print even when the job passed")
+	a.NotContains(output, "asserts[", "a passing job has no assertion failures to report")
+}
+
+func TestPrint_NoDebugOutputWhenPassedAndNoDebug(t *testing.T) {
+	flag := false
+	pr := printer.NewPrinter(new(bytes.Buffer), &flag)
+
+	tjr := TestJobResult{
+		DisplayName: "some job",
+		Passed:      true,
+	}
+
+	tjr.print(pr, 1)
+	assert.Empty(t, fmt.Sprintf("%s", pr.Writer), "passing job without debug must stay silent")
+}
+
+func TestStringify_ExcludesDebugOutput(t *testing.T) {
+	tjr := TestJobResult{
+		DisplayName: "some job",
+		Passed:      false,
+		DebugOutput: "#### file: chart/templates/deployment.yaml\nkind: Deployment\n",
+		AssertsResult: []*AssertionResult{
+			{Index: 0, FailInfo: []string{"expected"}, AssertType: "equal"},
+		},
+	}
+
+	// the XML formatters build their failure messages from Stringify, so rendered
+	// manifests must not leak into junit/xunit/nunit/sonar reports
+	a := assert.New(t)
+	a.NotContains(tjr.Stringify(), "kind: Deployment")
+	a.NotContains(tjr.StringifyToXmlAttribute(), "kind: Deployment")
+	a.Contains(tjr.Stringify(), "equal")
+}
+
+func TestPrint_DebugOutputDoesNotRepeatJobNameWhenFailed(t *testing.T) {
+	flag := false
+	pr := printer.NewPrinter(new(bytes.Buffer), &flag)
+
+	tjr := TestJobResult{
+		DisplayName: "some job",
+		Passed:      false,
+		DebugOutput: "#### file: chart/templates/deployment.yaml\nkind: Deployment\n",
+		AssertsResult: []*AssertionResult{
+			{Index: 0, FailInfo: []string{"expected"}, AssertType: "equal"},
+		},
+	}
+
+	tjr.print(pr, 1)
+	output := fmt.Sprintf("%s", pr.Writer)
+	assert.Equal(t, 1, strings.Count(output, "some job"),
+		"the job name should be printed once, not repeated by the debug output")
 }

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -205,6 +205,7 @@ type TestJob struct {
 	} `yaml:"skip"`
 	KubernetesProvider KubernetesFakeClientProvider `yaml:"kubernetesProvider"`
 	PostRendererConfig PostRendererConfig           `yaml:"postRenderer"`
+	Debug              bool                         `yaml:"debug"`
 
 	// global set values
 	globalSet map[string]any
@@ -238,6 +239,33 @@ func (t *TestJob) configOrDefault() TestConfig {
 	return t.config
 }
 
+// writeDebugOutput writes the rendered manifests to the configured debug writer
+// when debug is enabled on either this test job or its suite. The stage argument
+// labels output which is not the final post-rendered result; pass "" when it is.
+func (t *TestJob) writeDebugOutput(manifestsOfFiles map[string]string, stage string) {
+	config := t.configOrDefault()
+	if !t.Debug && !config.debug {
+		return
+	}
+
+	writer := config.debugWriterOrDefault()
+	// sort the keys so debug output is stable across runs
+	files := make([]string, 0, len(manifestsOfFiles))
+	for file := range manifestsOfFiles {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+
+	label := "file"
+	if stage != "" {
+		label = fmt.Sprintf("file (%s)", stage)
+	}
+	for _, file := range files {
+		fmt.Fprintf(writer, "#### %s: %s\n", label, file)
+		fmt.Fprintln(writer, manifestsOfFiles[file])
+	}
+}
+
 // RunV3 render the chart and validate it with assertions in TestJob.
 func (t *TestJob) RunV3(
 	result *results.TestJobResult,
@@ -266,9 +294,13 @@ func (t *TestJob) RunV3(
 
 	postRenderedManifestsOfFiles, didPostRender, err := t.postRender(outputOfFiles)
 	if err != nil {
+		// the chart itself rendered, so still show that output when debugging
+		t.writeDebugOutput(outputOfFiles, "pre-post-render")
 		result.ExecError = err
 		return result
 	}
+
+	t.writeDebugOutput(postRenderedManifestsOfFiles, "")
 
 	manifestsOfFiles, err := t.parseManifestsFromOutputOfFiles(postRenderedManifestsOfFiles, renderSucceed)
 	if err != nil {

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -239,16 +239,15 @@ func (t *TestJob) configOrDefault() TestConfig {
 	return t.config
 }
 
-// writeDebugOutput writes the rendered manifests to the configured debug writer
-// when debug is enabled on either this test job or its suite. The stage argument
-// labels output which is not the final post-rendered result; pass "" when it is.
-func (t *TestJob) writeDebugOutput(manifestsOfFiles map[string]string, stage string) {
-	config := t.configOrDefault()
-	if !t.Debug && !config.debug {
-		return
+// debugOutput renders the manifests into the text to show when debug is enabled
+// on either this test job or its suite, and returns an empty string when it is
+// not. The stage argument labels output which is not the final post-rendered
+// result; pass "" when it is.
+func (t *TestJob) debugOutput(manifestsOfFiles map[string]string, stage string) string {
+	if !t.Debug && !t.configOrDefault().debug {
+		return ""
 	}
 
-	writer := config.debugWriterOrDefault()
 	// sort the keys so debug output is stable across runs
 	files := make([]string, 0, len(manifestsOfFiles))
 	for file := range manifestsOfFiles {
@@ -260,10 +259,12 @@ func (t *TestJob) writeDebugOutput(manifestsOfFiles map[string]string, stage str
 	if stage != "" {
 		label = fmt.Sprintf("file (%s)", stage)
 	}
+	var output strings.Builder
 	for _, file := range files {
-		fmt.Fprintf(writer, "#### %s: %s\n", label, file)
-		fmt.Fprintln(writer, manifestsOfFiles[file])
+		fmt.Fprintf(&output, "#### %s: %s\n", label, file)
+		fmt.Fprintln(&output, manifestsOfFiles[file])
 	}
+	return output.String()
 }
 
 // RunV3 render the chart and validate it with assertions in TestJob.
@@ -295,12 +296,12 @@ func (t *TestJob) RunV3(
 	postRenderedManifestsOfFiles, didPostRender, err := t.postRender(outputOfFiles)
 	if err != nil {
 		// the chart itself rendered, so still show that output when debugging
-		t.writeDebugOutput(outputOfFiles, "pre-post-render")
+		result.DebugOutput = t.debugOutput(outputOfFiles, "pre-post-render")
 		result.ExecError = err
 		return result
 	}
 
-	t.writeDebugOutput(postRenderedManifestsOfFiles, "")
+	result.DebugOutput = t.debugOutput(postRenderedManifestsOfFiles, "")
 
 	manifestsOfFiles, err := t.parseManifestsFromOutputOfFiles(postRenderedManifestsOfFiles, renderSucceed)
 	if err != nil {

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -1366,18 +1366,15 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	var debugOutput bytes.Buffer
-	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
-		WithDebugWriter(&debugOutput),
-	))
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{}))
 	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	a.NoError(testResult.ExecError)
 	a.True(testResult.Passed)
 	a.True(tj.Debug, "debug should be unmarshalled from the test job definition")
-	a.Contains(debugOutput.String(), "#### file: basic/templates/deployment.yaml")
-	a.Contains(debugOutput.String(), "kind: Deployment")
+	a.Contains(testResult.DebugOutput, "#### file: basic/templates/deployment.yaml")
+	a.Contains(testResult.DebugOutput, "kind: Deployment")
 }
 
 func TestV3RunJobDebugWritesRenderedManifestsWhenSuiteDebugSet(t *testing.T) {
@@ -1393,10 +1390,8 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	var debugOutput bytes.Buffer
 	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
 		WithDebug(true),
-		WithDebugWriter(&debugOutput),
 	))
 	testResult := tj.RunV3(&results.TestJobResult{})
 
@@ -1404,8 +1399,8 @@ asserts:
 	a.NoError(testResult.ExecError)
 	a.True(testResult.Passed)
 	a.False(tj.Debug, "the job itself did not opt in; only the suite did")
-	a.Contains(debugOutput.String(), "#### file: basic/templates/deployment.yaml")
-	a.Contains(debugOutput.String(), "kind: Deployment")
+	a.Contains(testResult.DebugOutput, "#### file: basic/templates/deployment.yaml")
+	a.Contains(testResult.DebugOutput, "kind: Deployment")
 }
 
 func TestV3RunJobDebugWritesNothingWhenDebugNotSet(t *testing.T) {
@@ -1421,16 +1416,13 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	var debugOutput bytes.Buffer
-	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
-		WithDebugWriter(&debugOutput),
-	))
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{}))
 	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	a.NoError(testResult.ExecError)
 	a.True(testResult.Passed)
-	a.Empty(debugOutput.String(), "no debug output expected when neither job nor suite enables debug")
+	a.Empty(testResult.DebugOutput, "no debug output expected when neither job nor suite enables debug")
 }
 
 func TestV3RunJobDebugPrintsPostRenderedManifests(t *testing.T) {
@@ -1455,17 +1447,14 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	var debugOutput bytes.Buffer
-	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
-		WithDebugWriter(&debugOutput),
-	))
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{}))
 	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	a.NoError(testResult.ExecError)
 	a.True(testResult.Passed)
 	// debug output must reflect the POST-rendered manifest, not the raw render
-	a.Contains(debugOutput.String(), "appended: new")
+	a.Contains(testResult.DebugOutput, "appended: new")
 }
 
 func TestV3RunJobDebugPrintsRenderedManifestsWhenPostRenderFails(t *testing.T) {
@@ -1485,17 +1474,14 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	var debugOutput bytes.Buffer
-	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
-		WithDebugWriter(&debugOutput),
-	))
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{}))
 	testResult := tj.RunV3(&results.TestJobResult{})
 
 	a := assert.New(t)
 	a.Error(testResult.ExecError, "the failing post-renderer should be reported")
 	// the chart itself rendered fine, so debug must still show that output,
 	// clearly marked as being from before the post-renderer ran
-	a.Contains(debugOutput.String(), "pre-post-render")
-	a.Contains(debugOutput.String(), "basic/templates/deployment.yaml")
-	a.Contains(debugOutput.String(), "kind: Deployment")
+	a.Contains(testResult.DebugOutput, "pre-post-render")
+	a.Contains(testResult.DebugOutput, "basic/templates/deployment.yaml")
+	a.Contains(testResult.DebugOutput, "kind: Deployment")
 }

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 
 	"github.com/helm-unittest/helm-unittest/pkg/unittest/valueutils"
@@ -1349,4 +1350,152 @@ asserts:
 	a.NoError(testResult.ExecError)
 	a.True(testResult.Passed)
 	a.Equal(1, len(testResult.AssertsResult))
+}
+
+func TestV3RunJobDebugWritesRenderedManifestsWhenJobDebugSet(t *testing.T) {
+	c, _ := loader.Load(testV3BasicChart)
+	manifest := `
+it: should work
+debug: true
+asserts:
+  - equal:
+      path: kind
+      value: Deployment
+    template: templates/deployment.yaml
+`
+	var tj TestJob
+	common.YmlUnmarshalTestHelper(manifest, &tj, t)
+
+	var debugOutput bytes.Buffer
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithDebugWriter(&debugOutput),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
+
+	a := assert.New(t)
+	a.NoError(testResult.ExecError)
+	a.True(testResult.Passed)
+	a.True(tj.Debug, "debug should be unmarshalled from the test job definition")
+	a.Contains(debugOutput.String(), "#### file: basic/templates/deployment.yaml")
+	a.Contains(debugOutput.String(), "kind: Deployment")
+}
+
+func TestV3RunJobDebugWritesRenderedManifestsWhenSuiteDebugSet(t *testing.T) {
+	c, _ := loader.Load(testV3BasicChart)
+	manifest := `
+it: should work
+asserts:
+  - equal:
+      path: kind
+      value: Deployment
+    template: templates/deployment.yaml
+`
+	var tj TestJob
+	common.YmlUnmarshalTestHelper(manifest, &tj, t)
+
+	var debugOutput bytes.Buffer
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithDebug(true),
+		WithDebugWriter(&debugOutput),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
+
+	a := assert.New(t)
+	a.NoError(testResult.ExecError)
+	a.True(testResult.Passed)
+	a.False(tj.Debug, "the job itself did not opt in; only the suite did")
+	a.Contains(debugOutput.String(), "#### file: basic/templates/deployment.yaml")
+	a.Contains(debugOutput.String(), "kind: Deployment")
+}
+
+func TestV3RunJobDebugWritesNothingWhenDebugNotSet(t *testing.T) {
+	c, _ := loader.Load(testV3BasicChart)
+	manifest := `
+it: should work
+asserts:
+  - equal:
+      path: kind
+      value: Deployment
+    template: templates/deployment.yaml
+`
+	var tj TestJob
+	common.YmlUnmarshalTestHelper(manifest, &tj, t)
+
+	var debugOutput bytes.Buffer
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithDebugWriter(&debugOutput),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
+
+	a := assert.New(t)
+	a.NoError(testResult.ExecError)
+	a.True(testResult.Passed)
+	a.Empty(debugOutput.String(), "no debug output expected when neither job nor suite enables debug")
+}
+
+func TestV3RunJobDebugPrintsPostRenderedManifests(t *testing.T) {
+	if _, err := exec.LookPath("yq"); err != nil {
+		t.Skip("yq is not installed, skipping post-renderer debug test")
+	}
+	c, _ := loader.Load(testV3WithPostRendererChart)
+	manifest := `
+it: should print the post-rendered manifest
+debug: true
+postRenderer:
+  cmd: "yq"
+  args:
+    - "eval"
+    - '.metadata.annotations.appended="new"'
+    - "-"
+asserts:
+  - equal:
+      path: metadata.annotations.appended
+      value: new
+`
+	var tj TestJob
+	common.YmlUnmarshalTestHelper(manifest, &tj, t)
+
+	var debugOutput bytes.Buffer
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithDebugWriter(&debugOutput),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
+
+	a := assert.New(t)
+	a.NoError(testResult.ExecError)
+	a.True(testResult.Passed)
+	// debug output must reflect the POST-rendered manifest, not the raw render
+	a.Contains(debugOutput.String(), "appended: new")
+}
+
+func TestV3RunJobDebugPrintsRenderedManifestsWhenPostRenderFails(t *testing.T) {
+	c, _ := loader.Load(testV3BasicChart)
+	// a post-renderer that always fails, so RunV3 returns early
+	manifest := `
+it: should still show what was rendered
+debug: true
+postRenderer:
+  cmd: "false"
+asserts:
+  - equal:
+      path: kind
+      value: Deployment
+    template: templates/deployment.yaml
+`
+	var tj TestJob
+	common.YmlUnmarshalTestHelper(manifest, &tj, t)
+
+	var debugOutput bytes.Buffer
+	tj.WithConfig(*NewTestConfig(c, &snapshot.Cache{},
+		WithDebugWriter(&debugOutput),
+	))
+	testResult := tj.RunV3(&results.TestJobResult{})
+
+	a := assert.New(t)
+	a.Error(testResult.ExecError, "the failing post-renderer should be reported")
+	// the chart itself rendered fine, so debug must still show that output,
+	// clearly marked as being from before the post-renderer ran
+	a.Contains(debugOutput.String(), "pre-post-render")
+	a.Contains(debugOutput.String(), "basic/templates/deployment.yaml")
+	a.Contains(debugOutput.String(), "kind: Deployment")
 }

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -230,6 +230,7 @@ type TestSuite struct {
 	}
 	KubernetesProvider KubernetesFakeClientProvider `yaml:"kubernetesProvider"`
 	PostRendererConfig PostRendererConfig           `yaml:"postRenderer"`
+	Debug              bool                         `yaml:"debug"`
 
 	Tests []*TestJob
 	// where the test suite file located
@@ -415,6 +416,7 @@ func (s *TestSuite) runV3TestJobs(
 				WithDocumentSelector(testJob.DocumentSelector),
 				WithIncludeCrds(s.IncludeCrds),
 				WithSkipSchemaValidation(s.skipSchemaValidation),
+				WithDebug(s.Debug),
 			))
 			jobResult = testJob.RunV3(&job)
 			jobResults[idx] = jobResult

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -1,9 +1,7 @@
 package unittest_test
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"testing"
@@ -1965,33 +1963,6 @@ tests:
 	}
 }
 
-// captureStdout redirects os.Stdout for the duration of act, returning what was
-// written. Needed because suite-level debug output goes to stdout by default.
-func captureStdout(t *testing.T, act func()) string {
-	t.Helper()
-	original := os.Stdout
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("could not create pipe: %v", err)
-	}
-	os.Stdout = writer
-	defer func() { os.Stdout = original }()
-
-	captured := make(chan string, 1)
-	go func() {
-		var buffer bytes.Buffer
-		_, _ = io.Copy(&buffer, reader)
-		captured <- buffer.String()
-	}()
-
-	act()
-
-	if closeErr := writer.Close(); closeErr != nil {
-		t.Fatalf("could not close pipe writer: %v", closeErr)
-	}
-	return <-captured
-}
-
 func TestV3RunSuiteWithDebugPrintsRenderedManifests(t *testing.T) {
 	suiteDoc := `
 suite: test suite with debug
@@ -2016,15 +1987,13 @@ tests:
 	a.True(testSuite.Debug, "debug should be unmarshalled from the suite definition")
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_suite_debug_test.yaml"), false)
-	var suiteResult *results.TestSuiteResult
-	output := captureStdout(t, func() {
-		suiteResult = testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
-	})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
 
 	a.True(suiteResult.Passed)
-	a.Contains(output, "#### file: basic/templates/deployment.yaml",
+	a.Len(suiteResult.TestsResult, 1)
+	a.Contains(suiteResult.TestsResult[0].DebugOutput, "#### file: basic/templates/deployment.yaml",
 		"suite level debug should be passed down to every test job")
-	a.Contains(output, "kind: Deployment")
+	a.Contains(suiteResult.TestsResult[0].DebugOutput, "kind: Deployment")
 }
 
 func TestV3RunSuiteWithoutDebugPrintsNothing(t *testing.T) {
@@ -2050,11 +2019,9 @@ tests:
 	a.False(testSuite.Debug)
 
 	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_suite_nodebug_test.yaml"), false)
-	var suiteResult *results.TestSuiteResult
-	output := captureStdout(t, func() {
-		suiteResult = testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
-	})
+	suiteResult := testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
 
 	a.True(suiteResult.Passed)
-	a.NotContains(output, "#### file:", "no debug output expected when debug is not enabled")
+	a.Len(suiteResult.TestsResult, 1)
+	a.Empty(suiteResult.TestsResult[0].DebugOutput, "no debug output expected when debug is not enabled")
 }

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -1,7 +1,9 @@
 package unittest_test
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"testing"
@@ -1961,4 +1963,98 @@ tests:
 			}
 		})
 	}
+}
+
+// captureStdout redirects os.Stdout for the duration of act, returning what was
+// written. Needed because suite-level debug output goes to stdout by default.
+func captureStdout(t *testing.T, act func()) string {
+	t.Helper()
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("could not create pipe: %v", err)
+	}
+	os.Stdout = writer
+	defer func() { os.Stdout = original }()
+
+	captured := make(chan string, 1)
+	go func() {
+		var buffer bytes.Buffer
+		_, _ = io.Copy(&buffer, reader)
+		captured <- buffer.String()
+	}()
+
+	act()
+
+	if closeErr := writer.Close(); closeErr != nil {
+		t.Fatalf("could not close pipe writer: %v", closeErr)
+	}
+	return <-captured
+}
+
+func TestV3RunSuiteWithDebugPrintsRenderedManifests(t *testing.T) {
+	suiteDoc := `
+suite: test suite with debug
+debug: true
+templates:
+  - configmap.yaml
+  - deployment.yaml
+tests:
+  - it: should pass
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: kind
+          value: Deployment
+`
+	testSuite := TestSuite{}
+	common.YmlUnmarshalTestHelper(suiteDoc, &testSuite, t)
+	chart, chartErr := v3loader.Load(testV3BasicChart)
+	assert.NoError(t, chartErr)
+
+	a := assert.New(t)
+	a.True(testSuite.Debug, "debug should be unmarshalled from the suite definition")
+
+	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_suite_debug_test.yaml"), false)
+	var suiteResult *results.TestSuiteResult
+	output := captureStdout(t, func() {
+		suiteResult = testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	})
+
+	a.True(suiteResult.Passed)
+	a.Contains(output, "#### file: basic/templates/deployment.yaml",
+		"suite level debug should be passed down to every test job")
+	a.Contains(output, "kind: Deployment")
+}
+
+func TestV3RunSuiteWithoutDebugPrintsNothing(t *testing.T) {
+	suiteDoc := `
+suite: test suite without debug
+templates:
+  - configmap.yaml
+  - deployment.yaml
+tests:
+  - it: should pass
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: kind
+          value: Deployment
+`
+	testSuite := TestSuite{}
+	common.YmlUnmarshalTestHelper(suiteDoc, &testSuite, t)
+	chart, chartErr := v3loader.Load(testV3BasicChart)
+	assert.NoError(t, chartErr)
+
+	a := assert.New(t)
+	a.False(testSuite.Debug)
+
+	cache, _ := snapshot.CreateSnapshotOfSuite(path.Join(tmpdir, "v3_suite_nodebug_test.yaml"), false)
+	var suiteResult *results.TestSuiteResult
+	output := captureStdout(t, func() {
+		suiteResult = testSuite.RunV3(chart, cache, true, "", &results.TestSuiteResult{})
+	})
+
+	a.True(suiteResult.Passed)
+	a.NotContains(output, "#### file:", "no debug output expected when debug is not enabled")
 }

--- a/schema/helm-testsuite.json
+++ b/schema/helm-testsuite.json
@@ -34,6 +34,11 @@
       "description": "Include CRDs from the crds/ directory in the rendered output for testing. Mirrors the behavior of helm template --include-crds. Defaults to false.",
       "markdownDescription": "**includeCrds** (boolean) _optional_\n\nInclude CRDs from the `crds/` directory in the rendered output for testing. Mirrors the behavior of `helm template --include-crds`. Defaults to `false`."
     },
+    "debug": {
+      "type": "boolean",
+      "description": "Print the rendered manifests of every test job in this suite to stdout, to help diagnose failing tests. Defaults to false.",
+      "markdownDescription": "**debug** (boolean) _optional_\n\nPrint the rendered manifests of every test job in this suite to stdout, to help diagnose failing tests. Defaults to `false`."
+    },
     "release": {
       "$ref": "#/definitions/release"
     },
@@ -78,6 +83,11 @@
           },
           "postRenderer": {
             "$ref": "#/definitions/postRenderer"
+          },
+          "debug": {
+            "type": "boolean",
+            "description": "Print the rendered manifests of this test job to stdout, to help diagnose a failing test. Defaults to false.",
+            "markdownDescription": "**debug** (boolean) _optional_\n\nPrint the rendered manifests of this test job to stdout, to help diagnose a failing test. Defaults to `false`."
           },
           "template": {
             "type": "string",

--- a/test/data/v3/with-post-renderer/tests/basic_postrender_test.yaml
+++ b/test/data/v3/with-post-renderer/tests/basic_postrender_test.yaml
@@ -6,6 +6,7 @@ postRenderer:
     - "eval"
     - '.metadata.annotations.appended="new"'
     - "-"
+debug: true
 tests:
   - it: manifest should match snapshot
     asserts:


### PR DESCRIPTION
## What

Adds a `debug` option to a test suite and to an individual test job, which prints the rendered manifests alongside that test's result, to help diagnose a failing test.

```yaml
suite: my suite
debug: true          # every test job in this suite
templates:
  - deployment.yaml
tests:
  - it: should work
    debug: true      # or just this one test job
    asserts:
      - equal:
          path: kind
          value: Deployment
```

Relates to #281. This implements the approach I floated in https://github.com/helm-unittest/helm-unittest/issues/281#issuecomment-2699332922.

## Why

Today, seeing what helm-unittest actually rendered means reaching for something coarser than the problem:

- `-d/--debugPlugin` is global, turns on debug logging for the whole run, and writes every render into a `.debug` folder.
- the workarounds on #281 (a throwaway `matchSnapshot`, or a `postRenderer` of `tee`) both mean editing the test to get at the output.

The intended workflow here is narrow and deliberately unglamorous: a test fails, you add `debug: true` to that one test, look at the manifest, fix the problem and take the flag back off again.

## Behaviour

- Suite level enables it for every test job in the suite; test job level enables it for that job only.
- The two are OR'd, so a test job cannot disable what its suite enabled. This is deliberate, and documented.
- Output is nested under the name of the test job it belongs to, in the normal result output, so it sits next to the assertion diff rather than far above it.
- It is printed for passing tests too. It was explicitly asked for, so it is not conditional on failure.
- Output is taken **after** any `postRenderer` has been applied, so it shows exactly what the assertions validate.
- If a `postRenderer` itself fails, the chart has still been rendered, so that output is shown instead and labelled `pre-post-render`. Without this the option went silent in precisely the case you would reach for it.
- File names are sorted before printing, so output is stable across runs rather than following Go's randomised map iteration order.

## The two commits

Kept separate on purpose, as the second is a design change rather than a fix, and is straightforward to drop if you would rather have the first approach:

1. **`feat:`** adds the option, writing the manifests to stdout as each job runs.
2. **`refactor:`** buffers the output onto `TestJobResult` and prints it from `TestJobResult.print` instead. This is what puts the output next to the result, attributes it per test job, and picks up the printer's indentation and colouring. It also removes more than it adds: the `WithDebugWriter` option existed only to make the output assertable, and tests now read `result.DebugOutput` directly.

Happy to drop the second commit if you prefer the simpler write-as-you-go version.

## Notes for review

- `debug` is added to `schema/helm-testsuite.json` at **both** the suite root and inside `tests.items`, since `additionalProperties` is `false` for both.
- `DebugOutput` is deliberately excluded from `TestJobResult.Stringify`, since the junit/xunit/nunit/sonar formatters build their failure messages from it and rendered manifests should not end up in the reports. There is a test covering this.
- The snapshot churn is from the new field on `TestJobResult` changing its dump; the diffs are only that field. The one real change is `TestV3RunnerOkWithPostRenderer`, whose fixture enables debug and so now captures the printed output end to end.
- Written against the current `TestConfig`/`With*` options pattern rather than adding parameters to `RunV3`, so no existing call sites change.

Feedback on the option name, the OR precedence, and the output format all very welcome before I take this out of draft.

## Possible follow-up

#281 also asks for the rendered output on failure *without* having to opt in per test. That is a small addition on top of this (gate the same output on `!result.Passed` behind a separate option), but it is a new user-facing behaviour, so I have deliberately left it out of this PR. Happy to open a second one if that is wanted.

Worth noting while I was in here: `writeRenderedOutput` keys the `-d/--debugPlugin` output by chart-relative filename only, so every test job in every suite writes to the same path and the last one wins. Three renders across two suites collapse into one file. Unrelated to this change, and I have not touched it, but I can file it separately if it is not already known.

## Testing

- `gofmt -l -s .` clean, `go vet ./...` clean.
- `go test ./...` passes.
- 12 tests covering: per-job flag, per-suite flag reaching a non-opted-in job, the negative cases, post-rendered output, the `pre-post-render` path, both suite-level cases, output shown on pass and on failure, the job name not being repeated, and `Stringify` not leaking manifests into the xml reports. The post-renderer tests skip when `yq` is not on the path.
- Verified end-to-end with the built binary at both levels, on passing and failing tests.