### PR TITLE
test: add regression test for null value removing map keys in deep merge

### DIFF
--- a/pkg/unittest/valueutils/valueutils_test.go
+++ b/pkg/unittest/valueutils/valueutils_test.go
@@ -557,6 +557,16 @@ func TestMergeValues_SourceWithNilValue(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestMergeValues_NilRemovesKey(t *testing.T) {
+	// When source sets a key to null, it should remove the key from the merged result
+	// This matches real Helm behavior: null in values file removes the key
+	src := map[string]any{"a": map[string]any{"b": nil}}
+	dest := map[string]any{"a": map[string]any{"b": "keep", "c": 2}}
+	expected := map[string]any{"a": map[string]any{"c": 2}}
+	actual := v3util.MergeTables(dest, src)
+	assert.Equal(t, expected, actual)
+}
+
 func TestMergeValues_NestedMapWithEmptyMap(t *testing.T) {
 	src := map[string]any{"a": map[string]any{"b": 1}}
 	dest := map[string]any{"a": map[string]any{}}


### PR DESCRIPTION
Adds a regression test documenting that when a source values map sets a nested key to null, the merged result removes that key. This matches real Helm deep merge behavior.

The test uses v3util.MergeTables (from helm.sh/helm/v3/pkg/chartutil) which is the same function used during chart rendering.